### PR TITLE
Add Github action to publish tagged releases to PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,16 +31,40 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-pypi:
-    name: >-
-      Publish Python distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/') # Only publish to PyPi on tag pushes
+# Commented out to be added back when stable.
+# publish-to-pypi:
+#  name: >-
+#     Publish Python distribution to PyPI
+#   if: startsWith(github.ref, 'refs/tags/') # Only publish to PyPi on tag pushes
+#   needs:
+#   - build
+#   runs-on: ubuntu-latest
+#   environment:
+#     name: pypi
+#     url: https://pypi.org/p/spanner-graph-notebook
+#   permissions:
+#     id-token: write # IMPORTANT: mandatory for trusted publishing
+#
+#   steps:
+#   - name: Download all the dists
+#     uses: actions/download-artifact@v4
+#     with:
+#       name: python-package-distributions
+#       path: dist/
+#   - name: Publish distribution to PyPI
+#     uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    if: startsWith(github.ref, 'refs/tags/') # Only publish to Test.PyPi on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest
+
     environment:
-      name: pypi
-      url: https://pypi.org/p/spanner-graph-notebook
+      name: testpypi
+      url: https://test.pypi.org/p/spanner-graph-notebook
+
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
 
@@ -50,14 +74,16 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution to PyPI
+    - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
 
   github-release:
     name: >-
       Sign the Python distribution with Sigstore and upload them to Github relese
     needs:
-    - publish-to-pypi
+    - publish-to-testpypi # publish-to-pypi
     runs-on: ubuntu-latest
 
     permissions:
@@ -97,28 +123,3 @@ jobs:
         gh release upload
         '${{ github.ref_name }}' dist/*
         --repo '${{ github.repository }}'
-
-
-  publish-to-testpypi:
-    name: Publish Python distribution to TestPyPI
-    needs:
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/spanner-graph-notebook
-
-    permissions:
-      id-token: write # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,124 @@
+name: Publish to PyPi
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/') # Only publish to PyPi on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spanner-graph-notebook
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore and upload them to Github relese
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # IMPORTANT: mandatory for making Github releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+
+    - name: Create Github Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '{{ github.repository }}'
+        --notes ""
+
+    - name: Upload artifact signatures to GitHub release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to Github release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/*
+        --repo '${{ github.repository }}'
+
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/spanner-graph-notebook
+
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Whenever a tagged release is made, this Github action will publish it to Python's pypi and also to test.pypi to allow for pre-release testing too.

Fixes #5