### PR TITLE
Ensure shutdown of server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="spanner-graph-notebook",
-    version="v1.0.6",
+    version="v1.0.7",
     packages=find_packages(),
     install_requires=[
         "networkx", "numpy", "google-cloud-spanner", "ipython",

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -19,6 +19,7 @@ import threading
 import requests
 import portpicker
 from networkx.classes import DiGraph
+import atexit
 
 from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_native_numpy
 from spanner_graphs.database import get_database_instance
@@ -68,21 +69,36 @@ class GraphServer:
         "post_query": "/post_query",
     }
 
+    _server = None
+
     @staticmethod
     def build_route(endpoint):
         return f"{GraphServer.url}{endpoint}"
 
     @staticmethod
     def start_server():
-        with socketserver.TCPServer(("", GraphServer.port), GraphServerHandler) as httpd:
+        class ThreadedTCPServer(socketserver.TCPServer):
+            # Allow socket reuse to avoid "Address already in use" errors
+            allow_reuse_address = True
+            # Daemon threads automatically terminate when the main program exits
+            daemon_threads = True
+
+        with ThreadedTCPServer(("", GraphServer.port), GraphServerHandler) as httpd:
+            GraphServer._server = httpd
             print(f"Spanner Graph notebook loaded")
-            httpd.serve_forever()
+            GraphServer._server.serve_forever()
 
     @staticmethod
     def init():
         server_thread = threading.Thread(target=GraphServer.start_server)
         server_thread.start()
         return server_thread
+
+    @staticmethod
+    def stop_server():
+        if GraphServer._server:
+            GraphServer._server.shutdown()
+            print("Spanner Graph notebook shutting down...")
 
     @staticmethod
     def get_ping():
@@ -158,3 +174,6 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
             self.handle_post_ping()
         elif self.path == GraphServer.endpoints["post_query"]:
             self.handle_post_query()
+
+
+atexit.register(GraphServer.stop_server)

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -85,7 +85,7 @@ class GraphServer:
 
         with ThreadedTCPServer(("", GraphServer.port), GraphServerHandler) as httpd:
             GraphServer._server = httpd
-            print(f"Spanner Graph notebook loaded")
+            print(f"Spanner Graph Notebook loaded")
             GraphServer._server.serve_forever()
 
     @staticmethod
@@ -98,7 +98,7 @@ class GraphServer:
     def stop_server():
         if GraphServer._server:
             GraphServer._server.shutdown()
-            print("Spanner Graph notebook shutting down...")
+            print("Spanner Graph Notebook shutting down...")
 
     @staticmethod
     def get_ping():

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -15,10 +15,16 @@
 import unittest
 from spanner_graphs.graph_server import GraphServer
 
-class MyTestCase(unittest.TestCase):
+class TestSpannerServer(unittest.TestCase):
+    def setUp(self):
+        self.server_thread = GraphServer.init()
+
+    def tearDown(self):
+        GraphServer.stop_server()  # Stop the server after each test
+        self.server_thread.join()  # Wait for the thread to finish
+
     def test_ping(self):
-        thread = GraphServer.init()
-        self.assertTrue(thread.is_alive())
+        self.assertTrue(self.server_thread.is_alive())
 
         response = GraphServer.get_ping()
         self.assertEqual(response, {"message": "pong"})


### PR DESCRIPTION
## Summary

Fixes issue where the `server_test.py` test suite would hang indefinitely due to the server not shutting down properly.

Fixes #9 

Thank you @cqian23 for spearheading the solution!

## Changes

- **GraphServer Enhancements:**
  - Added a `stop_server` method to allow for a controlled shutdown of the server.
  - Utilized a `ThreadedTCPServer` class to handle socket reuse and daemon thread management, preventing "Address already in use" errors and ensuring threads terminate with the main program.
  - Registered the `stop_server` method with `atexit` to automatically shut down the server when the application exits.

- **Testing Improvements:**
  - Updated the test suite to start the server in the `setUp` method and stop it in the `tearDown` method, ensuring each test runs in a clean environment.
  - Renamed the test class to `TestSpannerServer` for clarity and consistency.
  - Fixed the hanging issue in the `server_test.py` test suite, which previously required a manual interrupt to terminate.