### PR TITLE
Add Table View

### DIFF
--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -49,7 +49,8 @@ def execute_query(project: str, instance: str, database: str, query: str, mock =
                 "nodes": nodes,
                 "edges": edges,
                 "schema": schema_json,
-                "rows": rows
+                "rows": rows,
+                "query_result": query_result
             }
         }
     except Exception as e:

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -81,6 +81,7 @@ def _generate_html(query, project: str, instance: str, database: str, mock: bool
         edge_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'edge.js'])
         config_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-config.js'])
         store_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-store.js'])
+        menu_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-menu.js'])
         graph_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-forcegraph.js'])
         sidebar_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-sidebar.js'])
         server_content = _load_file([search_dir, 'templates', 'spanner-graph', 'graph-server.js'])
@@ -101,6 +102,7 @@ def _generate_html(query, project: str, instance: str, database: str, mock: bool
             node_content=node_content,
             edge_content=edge_content,
             config_content=config_content,
+            menu_content=menu_content,
             graph_content=graph_content,
             store_content=store_content,
             sidebar_content=sidebar_content,

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -84,6 +84,7 @@ def _generate_html(query, project: str, instance: str, database: str, mock: bool
         menu_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-menu.js'])
         graph_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-forcegraph.js'])
         sidebar_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-sidebar.js'])
+        table_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-table.js'])
         server_content = _load_file([search_dir, 'templates', 'spanner-graph', 'graph-server.js'])
         app_content = _load_file([search_dir, 'templates', 'spanner-graph', 'app.js'])
 
@@ -106,6 +107,7 @@ def _generate_html(query, project: str, instance: str, database: str, mock: bool
             graph_content=graph_content,
             store_content=store_content,
             sidebar_content=sidebar_content,
+            table_content=table_content,
             server_content=server_content,
             app_content=app_content,
             query=query,

--- a/templates/spanner-graph/app.js
+++ b/templates/spanner-graph/app.js
@@ -34,6 +34,10 @@ class SpannerApp {
      */
     store = null;
     /**
+     * @type {SpannerMenu}
+     */
+    menu = null;
+    /**
      * @type {Sidebar}
      */
     sidebar = null;
@@ -44,6 +48,21 @@ class SpannerApp {
 
     lastQuery = '';
 
+    componentMounts = {
+        /**
+         * @type {HTMLElement}
+         */
+        menu: null,
+        /**
+         * @type {HTMLElement}
+         */
+        graph: null,
+        /**
+         * @type {HTMLElement}
+         */
+        sidebar: null
+    };
+
     constructor({id, url, project, instance, database, mock, mount, query}) {
         this.id = id;
         this.lastQuery = query;
@@ -53,6 +72,8 @@ class SpannerApp {
             throw Error("Must have a valid HTML element to mount the app");
         }
         this.mount = mount;
+
+        this.scaffold();
 
         this.server = new GraphServer(url, project, instance, database, mock);
         this.server.query(query)
@@ -91,22 +112,20 @@ class SpannerApp {
                 });
 
                 this.store = new GraphStore(graphConfig);
-                this.sidebar = new Sidebar(this.store, this.mount.querySelector(`#sidebar-${this.id}`));
+                this.menu = new SpannerMenu(this.store, this.componentMounts.menu);
+                this.sidebar = new Sidebar(this.store, this.componentMounts.sidebar);
                 this.graph = new GraphVisualization(this.store,
-                    this.mount.querySelector(`#force-graph-${this.id}`),
-                    this.mount.querySelector(`#graph-menu-${this.id}`));
+                    this.componentMounts.graph, this.componentMounts.menu);
 
                 const graphContainer = this.mount.querySelector(`#graph-container-${this.id}`);
                 graphContainer.className =
-                    this.store.viewMode === GraphStore.ViewModes.DEFAULT ? 'dots' : '';
+                    this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT ? 'dots' : '';
 
                 this.store.addEventListener(GraphStore.EventTypes.VIEW_MODE_CHANGE,
                     (viewMode, config) => {
-                        graphContainer.className = viewMode === GraphStore.ViewModes.DEFAULT ? 'dots' : '';
+                        graphContainer.className = viewMode === GraphConfig.ViewModes.DEFAULT ? 'dots' : '';
                     });
             });
-
-        this.scaffold();
     }
 
     scaffold() {
@@ -224,5 +243,8 @@ class SpannerApp {
 
         this.loaderElement = this.mount.querySelector('.loader-container');
         this.errorElement = this.mount.querySelector('.error');
+        this.componentMounts.menu = this.mount.querySelector(`#graph-menu-${this.id}`);
+        this.componentMounts.graph = this.mount.querySelector(`#force-graph-${this.id}`);
+        this.componentMounts.sidebar = this.mount.querySelector(`#sidebar-${this.id}`);
     }
 }

--- a/templates/spanner-graph/models/schema.js
+++ b/templates/spanner-graph/models/schema.js
@@ -83,6 +83,10 @@ class Schema {
     constructor(rawSchemaObject) {
         this.rawSchema = rawSchemaObject;
 
+        if (!(rawSchemaObject instanceof Object)) {
+            return;
+        }
+
         if (!this.rawSchema.edgeTables || !Array.isArray(this.rawSchema.edgeTables)) {
             this.rawSchema.edgeTables = [];
         }
@@ -134,6 +138,10 @@ class Schema {
      * @returns {Array<string>}
      */
     getUniqueLabels(tables) {
+        if (!Array.isArray(tables)) {
+            return [];
+        }
+
         /**
          * @type {Array<string>}
          */
@@ -161,6 +169,10 @@ class Schema {
      * @returns {Array<string>}
      */
     getNodeNames() {
+        if (!this.rawSchema || !Array.isArray(this.rawSchema.nodeTables)) {
+            return [];
+        }
+
         return this.getUniqueLabels(this.rawSchema.nodeTables);
     }
 
@@ -168,6 +180,10 @@ class Schema {
      * @returns {Array<string>}
      */
     getEdgeNames() {
+        if (!this.rawSchema || !Array.isArray(this.rawSchema.edgeTables)) {
+            return [];
+        }
+
         return this.getUniqueLabels(this.rawSchema.edgeTables);
     }
 

--- a/templates/spanner-graph/spanner-config.js
+++ b/templates/spanner-graph/spanner-config.js
@@ -52,6 +52,12 @@ class GraphConfig {
     rowsData = [];
 
     /**
+     * rowsData grouped by fields that were specified in the user's query.
+     * @type {Object}
+     */
+    queryResult = {};
+
+    /**
      * The currently focused GraphObject. This is usually the
      * node or edge that the user is hovering their mouse over.
      * @type {GraphObject}
@@ -130,7 +136,6 @@ class GraphConfig {
     lastLayoutMode = GraphConfig.LayoutModes.FORCE;
 
     showLabels = false;
-    lastShowLabels = false;
 
     /**
      * Constructs a new GraphConfig instance.
@@ -141,9 +146,11 @@ class GraphConfig {
      * @param {Array} [config.colorPalette] - An optional array of colors to use as the color palette.
      * @param {GraphConfig.ColorScheme} [config.colorScheme] - Color scheme can be optionally declared.
      * @param {Array} [config.rowsData] - Raw row data from Spanner
+     * @param {Object} [config.queryResult] - key-value pair: [field_name: str]: [...config.rowsData]. This
+     * has the same data as config.rowsData, but it is grouped by a field name written by the user in their query string.
      * @param {RawSchema} config.schemaData - Raw schema data from Spanner
      */
-    constructor({ nodesData, edgesData, colorPalette, colorScheme, rowsData, schemaData}) {
+    constructor({ nodesData, edgesData, colorPalette, colorScheme, rowsData, schemaData, queryResult}) {
         this.nodes = this.parseNodes(nodesData);
         this.edges = this.parseEdges(edgesData);
         this.nodeColors = this.assignColors(this.nodes);
@@ -158,6 +165,7 @@ class GraphConfig {
         }
 
         this.rowsData = rowsData;
+        this.queryResult = queryResult;
     }
 
     /**
@@ -204,6 +212,10 @@ class GraphConfig {
      * @throws {Error} Throws an error if the schema data can not be parsed
      */
     parseSchema(schemaData) {
+        if (!(schemaData instanceof Object)) {
+            return;
+        }
+
         this.schema = new Schema(schemaData);
 
         const nodesData = this.schema.rawSchema.nodeTables.map(

--- a/templates/spanner-graph/spanner-config.js
+++ b/templates/spanner-graph/spanner-config.js
@@ -111,6 +111,27 @@ class GraphConfig {
         LABEL: Symbol('label')
     });
 
+    static ViewModes = Object.freeze({
+        DEFAULT: Symbol('DEFAULT'),
+        SCHEMA: Symbol('SCHEMA'),
+        TABLE: Symbol('TABLE'),
+    });
+
+    static LayoutModes = Object.freeze({
+        FORCE: Symbol('FORCE'),
+        TOP_DOWN: Symbol('TOP_DOWN'),
+        LEFT_RIGHT: Symbol('LEFT_RIGHT'),
+        RADIAL_IN: Symbol('RADIAL_IN'),
+        RADIAL_OUT: Symbol('RADIAL_OUT'),
+    })
+
+    viewMode = GraphConfig.ViewModes.DEFAULT;
+    layoutMode = GraphConfig.LayoutModes.FORCE;
+    lastLayoutMode = GraphConfig.LayoutModes.FORCE;
+
+    showLabels = false;
+    lastShowLabels = false;
+
     /**
      * Constructs a new GraphConfig instance.
      * @constructor

--- a/templates/spanner-graph/spanner-store.js
+++ b/templates/spanner-graph/spanner-store.js
@@ -160,21 +160,15 @@ class GraphStore {
     }
 
     /**
-     * @param {ViewModes} viewMode
+     * @param {GraphConfig.ViewModes} viewMode
      */
     setViewMode(viewMode) {
+        if (viewMode === this.config.viewMode) {
+            return;
+        }
+
         this.setFocusedObject(null);
         this.setSelectedObject(null);
-
-        if (viewMode !== this.config.viewMode && viewMode === GraphConfig.ViewModes.DEFAULT) {
-            this.setLayoutMode(this.config.lastLayoutMode);
-            this.showLabels(this.config.lastShowLabels);
-        }
-
-        if (viewMode === GraphConfig.ViewModes.SCHEMA) {
-            this.setLayoutMode(GraphConfig.LayoutModes.FORCE);
-            this.showLabels(true);
-        }
 
         this.config.viewMode = viewMode;
         this.eventListeners[GraphStore.EventTypes.VIEW_MODE_CHANGE]
@@ -185,7 +179,6 @@ class GraphStore {
      * @param {Boolean} visible
      */
     showLabels(visible) {
-        this.config.lastShowLabels = this.config.showLabels;
         this.config.showLabels = visible;
         this.eventListeners[GraphStore.EventTypes.SHOW_LABELS]
             .forEach(callback => callback(visible, this.config));

--- a/templates/spanner-graph/spanner-store.js
+++ b/templates/spanner-graph/spanner-store.js
@@ -42,7 +42,22 @@
 
 /**
  * @callback ViewModeChangedCallback
- * @param {ViewModes} ViewMode - The color scheme to use for nodes.
+ * @param {GraphConfig.ViewModes} ViewMode - Whether to show the graph, table, or schema view.
+ * @param {GraphConfig} config - The graph configuration.
+ * @returns {void}
+ */
+
+/**
+ * @callback LayoutModeChangedCallback
+ * @param {GraphConfig.LayoutModes} layoutMode - The layout of the nodes (i.e. force directed, DAG, etc...)
+ * @param {LayoutModes} lastLayoutMode - The previous layout used.
+ * @param {GraphConfig} config - The graph configuration.
+ * @returns {void}
+ */
+
+/**
+ * @callback ShowLabelsCallback
+ * @param {Boolean} visible - Whether the labels are visible or not.
  * @param {GraphConfig} config - The graph configuration.
  * @returns {void}
  */
@@ -72,15 +87,10 @@ class GraphStore {
         FOCUS_OBJECT: Symbol('focusObject'),
         SELECT_OBJECT: Symbol('selectObject'),
         COLOR_SCHEME: Symbol('colorScheme'),
-        VIEW_MODE_CHANGE: Symbol('viewModeChange')
+        VIEW_MODE_CHANGE: Symbol('viewModeChange'),
+        LAYOUT_MODE_CHANGE: Symbol('layoutModeChange'),
+        SHOW_LABELS: Symbol('showLabels')
     });
-
-    static ViewModes = Object.freeze({
-        DEFAULT: Symbol('Default'),
-        SCHEMA: Symbol('Schema')
-    });
-
-    viewMode = GraphStore.ViewModes.DEFAULT;
 
     /**
      * Events that are broadcasted to GraphVisualization implementations. 
@@ -107,7 +117,15 @@ class GraphStore {
         /**
          * @type {GraphStore.EventTypes.VIEW_MODE_CHANGE, ViewModeChangedCallback[]>}
          */
-        [GraphStore.EventTypes.VIEW_MODE_CHANGE]: []
+        [GraphStore.EventTypes.VIEW_MODE_CHANGE]: [],
+        /**
+         * @type {GraphStore.EventTypes.LAYOUT_MODE_CHANGE, LayoutModeChangedCallback[]>}
+         */
+        [GraphStore.EventTypes.LAYOUT_MODE_CHANGE]: [],
+        /**
+         * @type {GraphStore.EventTypes.SHOW_LABELS, ShowLabelsCallback[]>}
+         */
+        [GraphStore.EventTypes.SHOW_LABELS]: []
     };
 
     /**
@@ -147,9 +165,40 @@ class GraphStore {
     setViewMode(viewMode) {
         this.setFocusedObject(null);
         this.setSelectedObject(null);
-        this.viewMode = viewMode;
+
+        if (viewMode !== this.config.viewMode && viewMode === GraphConfig.ViewModes.DEFAULT) {
+            this.setLayoutMode(this.config.lastLayoutMode);
+            this.showLabels(this.config.lastShowLabels);
+        }
+
+        if (viewMode === GraphConfig.ViewModes.SCHEMA) {
+            this.setLayoutMode(GraphConfig.LayoutModes.FORCE);
+            this.showLabels(true);
+        }
+
+        this.config.viewMode = viewMode;
         this.eventListeners[GraphStore.EventTypes.VIEW_MODE_CHANGE]
             .forEach(callback => callback(viewMode, this.config));
+    }
+
+    /**
+     * @param {Boolean} visible
+     */
+    showLabels(visible) {
+        this.config.lastShowLabels = this.config.showLabels;
+        this.config.showLabels = visible;
+        this.eventListeners[GraphStore.EventTypes.SHOW_LABELS]
+            .forEach(callback => callback(visible, this.config));
+    }
+
+    /**
+     * @param {LayoutModes} layoutMode
+     */
+    setLayoutMode(layoutMode) {
+        this.config.lastLayoutMode = this.config.layoutMode;
+        this.config.layoutMode = layoutMode;
+        this.eventListeners[GraphStore.EventTypes.LAYOUT_MODE_CHANGE]
+        .forEach(callback => callback(layoutMode, this.config.lastLayoutMode, this.config));
     }
 
     /**
@@ -291,14 +340,14 @@ class GraphStore {
             console.error('Node must have a label', node);
         }
 
-        switch (this.viewMode) {
-            case GraphStore.ViewModes.SCHEMA:
+        switch (this.config.viewMode) {
+            case GraphConfig.ViewModes.SCHEMA:
                 const schemaColor = this.config.schemaNodeColors[node.label];
                 if (schemaColor) {
                     return schemaColor;
                 }
                 break;
-            case GraphStore.ViewModes.DEFAULT:
+            case GraphConfig.ViewModes.DEFAULT:
                 const nodeColor = this.config.nodeColors[node.label];
                 if (nodeColor) {
                     return nodeColor;
@@ -331,10 +380,10 @@ class GraphStore {
      * @returns {Array<Node>|*[]}
      */
     getNodes() {
-        switch (this.viewMode) {
-            case GraphStore.ViewModes.DEFAULT:
+        switch (this.config.viewMode) {
+            case GraphConfig.ViewModes.DEFAULT:
                 return this.config.nodes;
-            case GraphStore.ViewModes.SCHEMA:
+            case GraphConfig.ViewModes.SCHEMA:
                 return this.config.schemaNodes;
             default:
                 return [];
@@ -345,10 +394,10 @@ class GraphStore {
      * @returns {Array<Edge>|*[]}
      */
     getEdges() {
-        switch (this.viewMode) {
-            case GraphStore.ViewModes.DEFAULT:
+        switch (this.config.viewMode) {
+            case GraphConfig.ViewModes.DEFAULT:
                 return this.config.edges;
-            case GraphStore.ViewModes.SCHEMA:
+            case GraphConfig.ViewModes.SCHEMA:
                 return this.config.schemaEdges;
             default:
                 return [];

--- a/templates/spanner-graph/visualization/spanner-forcegraph.js
+++ b/templates/spanner-graph/visualization/spanner-forcegraph.js
@@ -142,44 +142,6 @@ class GraphVisualization {
         LABEL: Symbol('Force directed')
     });
 
-    /**
-     * @typedef {Object} MenuConfig
-     * @property {ClusterMethod} clusterBy - Speed of zooming in.
-     */
-    /**
-     * @typedef {Object} MenuElements
-     * @property {HTMLElement|null} cluster - The element that toggles cluster method
-     */
-
-    /**
-     *
-     * @type {
-     *  {
-     *  layout: {lastLayout: null,
-     *  currentLayout: null},
-     *  elements: {cluster: HTMLElement,
-     *  layoutDropdownToggle: HTMLElement,
-     *  layoutDropdownContent: HTMLElement,
-     *  elementCount: HTMLElement},
-     *  config: {clusterBy: symbol}
-     *  }}
-     */
-    menu = {
-        elements: {
-            cluster: null,
-            layoutDropdownToggle: null,
-            layoutDropdownContent: null,
-            elementCount: null,
-        },
-        config: {
-            clusterBy: GraphVisualization.ClusterMethod.NEIGHBORHOOD
-        },
-        layout: {
-            lastLayout: null,
-            currentLayout: null
-        }
-    };
-
     // key is the amount of nodes in the ground
     static GraphSizes = Object.freeze({
         SMALL: Symbol('Small'),
@@ -227,7 +189,6 @@ class GraphVisualization {
         this.initializeEvents(this.store);
         this.graph = ForceGraph()(this.mount);
         this._setupGraphTools(this.graph);
-        this._setupMenu(this.graph);
         this._setupDrawLabelsOnEdges(this.graph);
         this._setupLineLength(this.graph);
         this._setupDrawNodes(this.graph);
@@ -304,6 +265,9 @@ class GraphVisualization {
                 }
             });
 
+        store.addEventListener(GraphStore.EventTypes.LAYOUT_MODE_CHANGE,
+            (layoutMode, lastLayoutMode) => this.onLayoutModeChange(layoutMode, lastLayoutMode));
+
         document.addEventListener('keydown', (event) => {
             if (event.key === 'Escape') {
                 this.store.setSelectedObject(null); // Deselect any selected node/edge
@@ -315,23 +279,64 @@ class GraphVisualization {
      * @type ViewModeChangedCallback
      */
     onViewModeChange(viewMode, config) {
+        if (viewMode === GraphConfig.ViewModes.TABLE) {
+            this.graph.pauseAnimation();
+        } else {
+            this.graph.resumeAnimation();
+        }
+
         this.requestedRecenter = true;
         this.graph.graphData({
             nodes: this.store.getNodes(),
             links: this._computeCurvature(this.store.getEdges())
         });
+    }
 
-        this.menu.elements.layoutDropdownContent.classList.remove('disabled', 'hidden');
-        this.menu.elements.layoutDropdownToggle.classList.remove('disabled', 'hidden');
-        this.menu.elements.elementCount.classList.remove('hidden');
-        if (viewMode === GraphStore.ViewModes.SCHEMA) {
-            this.graph.dagMode('');
-            this.menu.elements.layoutDropdownContent.classList.add('disabled', 'hidden');
-            this.menu.elements.layoutDropdownToggle.classList.add('disabled', 'hidden');
-            this.menu.elements.elementCount.classList.add('hidden');
-        } else {
-            this.graph.dagMode(this.menu.config.currentLayout);
+    /**
+     * @type LayoutModeChangedCallback
+     */
+    onLayoutModeChange(layoutMode, lastLayoutMode, config) {
+        let dagDistance;
+        let collisionRadius = 1; // Default collision radius
+
+        /**
+         * See "setDagMode": https://github.com/vasturiano/force-graph
+         * @type {string}
+         */
+        let forceGraphLayoutModeString = '';
+
+        switch (layoutMode) {
+            case GraphConfig.LayoutModes.FORCE:
+                dagDistance = 0; // Not applicable for force layout
+                break;
+            case GraphConfig.LayoutModes.TOP_DOWN:
+                forceGraphLayoutModeString = 'td';
+                dagDistance = Math.log10(this.store.config.nodes.length) * 50;
+                collisionRadius = 12;
+                break;
+            case GraphConfig.LayoutModes.LEFT_RIGHT:
+                forceGraphLayoutModeString = 'lr';
+                dagDistance = Math.log10(this.store.config.nodes.length) * 100;
+                collisionRadius = 12;
+                break;
+            case GraphConfig.LayoutModes.RADIAL_IN:
+                forceGraphLayoutModeString = 'radialin';
+                dagDistance = Math.log10(this.store.config.nodes.length) * 100;
+                collisionRadius = 8;
+                break;
+            case GraphConfig.LayoutModes.RADIAL_OUT:
+                forceGraphLayoutModeString = 'radialout';
+                dagDistance = Math.log10(this.store.config.nodes.length) * 100;
+                collisionRadius = 8;
+                break;
         }
+
+        this.graph.dagMode(forceGraphLayoutModeString);
+        this.graph.dagLevelDistance(dagDistance);
+
+        // Update d3Force collision
+        this.requestedRecenter = true;
+        this.graph.d3Force('collide', d3.forceCollide(collisionRadius));
     }
 
     _setupGraphTools(graphObject) {
@@ -439,330 +444,6 @@ class GraphVisualization {
         }
     }
 
-    _setupMenu() {
-        this.menuMount.innerHTML = `
-            <style>
-                header {
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                }
-                .menu-bar {
-                    align-items: center;
-                    border-bottom: 1px solid #DADCE0;
-                    box-sizing: border-box;
-                    color: #3C4043;
-                    display: flex;
-                    padding: 16px 24px 16px 16px;
-                    width: 100%;
-                    background: #fff;
-                }
-                .menu-item {
-                    display: flex;
-                    margin-right: 16px;
-                }
-                .menu-bar .hidden {
-                    visibility: hidden;
-                }
-                .toggle-container {
-                    display: flex;
-                    align-items: center;
-                    height: 100%;
-                    margin-left: 10px;
-                }
-                .toggle-switch {
-                    position: relative;
-                    display: inline-block;
-                    width: 46px;
-                    height: 24px;
-                    flex-shrink: 0;
-                }
-                .toggle-switch input {
-                    opacity: 0;
-                    width: 0;
-                    height: 0;
-                    margin: 0;
-                    padding: 0;
-                }
-                .toggle-slider {
-                    position: absolute;
-                    cursor: pointer;
-                    top: 0;
-                    left: 0;
-                    right: 0;
-                    bottom: 0;
-                    background-color: #e9ecef;
-                    transition: .4s;
-                    border-radius: 24px;
-                }
-                .toggle-slider:before {
-                    position: absolute;
-                    content: "";
-                    height: 18px;
-                    width: 18px;
-                    left: 3px;
-                    bottom: 3px;
-                    background-color: white;
-                    transition: .3s;
-                    border-radius: 50%;
-                }
-                input:checked + .toggle-slider {
-                    background-color: #228be6;
-                }
-                input:checked + .toggle-slider:before {
-                    transform: translateX(22px);
-                }
-                .toggle-label {
-                    margin-left: 8px;
-                    color: #202124;
-                    line-height: 24px;
-                }
-                .graph-element-tooltip {
-                    font: 12px 'Google Sans', 'Roboto', sans-serif;
-                    position: absolute;
-                    padding: 4px 8px;
-                    box-sizing: border-box;
-                    pointer-events: none;
-                    transition: opacity 0.2s ease-in-out;
-                    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-                    border-radius: 4px;
-                }
-                
-                /* Ensure .graph-tooltip built-in from force-graph does not interfere */
-                .graph-tooltip {
-                    background: none !important;
-                    border: none !important;
-                    padding: 0 !important;
-                }
-
-                .menu-bar .dropdown {
-                    margin-right: 16px;
-                    position: relative;
-                }
-
-                .dropdown-toggle {
-                    appearance: none;
-                    background: url("data:image/svg+xml;utf8,<svg fill='rgba(73, 80, 87, 1)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>") no-repeat;
-                    background-position: right 10px center;
-                    background-color: white;
-                    padding: 12px 40px 12px 16px;
-                    border: 1px solid #80868B;
-                    border-radius: 4px;
-                    color: #3C4043;
-                    cursor: pointer;
-                    font-size: 16px;
-                    text-align: left;
-                    width: 260px;
-                }
-                
-                .dropdown-toggle.disabled {
-                    background: url("data:image/svg+xml;utf8,<svg fill='rgba(73, 80, 87, .6)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>") no-repeat;
-                    background-position: right 10px center;
-                    background-color: #EBEBE4;
-                    border: 1px solid #EBEBE4;
-                    cursor: default;
-                }
-
-                .arrow-down {
-                    margin-left: 5px;
-                    font-size: 10px;
-                }
-
-                .menu-bar .dropdown .dropdown-content {
-                    display: none;
-                    position: absolute;
-                    background-color: #fff;
-                    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-                    z-index: 1;
-                    top: 100%;
-                    left: 0;
-                    padding: 8px 0;
-                }
-
-                .menu-bar .dropdown:hover .dropdown-content:not(.disabled) {
-                    display: block;
-                }
-
-                .menu-bar .dropdown .dropdown-item {
-                    color: #495057;
-                    padding: 8px 32px 8px 8px;
-                    text-decoration: none;
-                    display: flex;
-                    align-items: center;
-                }
-
-                .menu-bar .dropdown .dropdown-item.selected {
-                    background: url("data:image/svg+xml;utf8,<svg height='24' viewBox='0 0 24 24' width='24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M2 6L5 9L10 3' stroke='rgba(73, 80, 87, 1)' stroke-width='2' stroke-linecap='square'/></svg>") no-repeat;
-                    background-position: left 15px top 100%;
-                }
-
-                .menu-bar .dropdown .dropdown-item:hover {
-                    background-color: #f8f9fa;
-                }
-
-                .checkmark {
-                    width: 20px;
-                    margin-right: 8px;
-                }
-
-                .element-count {
-                    color: #000;
-                    display: flex;
-                    flex: 1;
-                    font-weight: 500;
-                }
-
-                .item-text {
-                    flex: 1;
-                }
-                
-                #graph-tools {
-                    position: absolute;
-                    bottom: 16px;
-                    right: 16px;
-                }
-        
-                #graph-tools button {
-                    display: block;
-                    width: 40px;
-                    height: 40px;
-                    background-color: transparent;
-                    border: none;
-                    border-radius: 20px;
-                    cursor: pointer;
-                }
-        
-                #graph-tools button:hover {
-                    background-color: rgba(26, 115, 232, .08);
-                }
-            </style>
-            <div class="menu-bar">
-                <div class="dropdown">
-                    <button class="dropdown-toggle">
-                        Force layout
-                    </button>
-                    <div class="dropdown-content">
-                        <a href="#" class="dropdown-item selected" data-layout="">
-                            <span class="checkmark"></span>
-                            <span class="item-text">Force layout</span>
-                        </a>
-                        <a href="#" class="dropdown-item" data-layout="td">
-                            <span class="checkmark"></span>
-                            <span class="item-text">Hierarchical: Top down</span>
-                        </a>
-                        <a href="#" class="dropdown-item" data-layout="lr">
-                            <span class="checkmark"></span>
-                            <span class="item-text">Hierarchical: Left-to-right</span>
-                        </a>
-                        <a href="#" class="dropdown-item" data-layout="radialin">
-                            <span class="checkmark"></span>
-                            <span class="item-text">Radial: Inward</span>
-                        </a>
-                        <a href="#" class="dropdown-item" data-layout="radialout">
-                            <span class="checkmark"></span>
-                            <span class="item-text">Radial: Outward</span>
-                        </a>
-                    </div>
-                </div>
-                
-                <div class="element-count">
-                    ${this.store.config.nodes.length} nodes, ${this.store.config.edges.length} edges
-                </div>
-                <div class="toggle-container">
-                    <label class="toggle-switch">
-                        <input id="view-schema" type="checkbox">
-                        <span class="toggle-slider"></span>
-                    </label>
-                    <span class="toggle-label">View Schema</span>
-                </div>
-                <div class="toggle-container">
-                    <label class="toggle-switch">
-                        <input id="show-labels" type="checkbox">
-                        <span class="toggle-slider"></span>
-                    </label>
-                    <span class="toggle-label">Show labels</span>
-                </div>
-            </div>`;
-
-        this.menu.elements.layoutButtons = this.menuMount.querySelectorAll('.dropdown-item');
-        this.menu.elements.layoutDropdownToggle = this.menuMount.querySelector('.dropdown-toggle');
-        this.menu.elements.layoutDropdownContent = this.menuMount.querySelector('.dropdown-content');
-        this.menu.elements.layoutDropdownContent.addEventListener('click', e => {
-            e.preventDefault();
-            
-            const title = this.menuMount.querySelector('.dropdown-toggle');
-            const layoutButton = e.target.closest('.dropdown-item');
-            if (!layoutButton) return;
-        
-            this.menu.elements.layoutButtons.forEach(button => {
-                button.className = button === layoutButton ? 'dropdown-item selected' : 'dropdown-item';
-            });
-            
-            if (title) {
-                title.textContent = layoutButton.textContent;
-            }
-            
-           try {
-                const newLayout = layoutButton.getAttribute('data-layout');
-                this.menu.config.lastLayout = this.graph.dagMode;
-                this.menu.config.currentLayout = newLayout;
-
-                let dagDistance;
-                let collisionRadius = 1; // Default collision radius
-
-                switch (newLayout) {
-                    case 'td': // Hierarchical: Top down
-                        dagDistance = Math.log10(this.store.config.nodes.length) * 50;
-                        collisionRadius = 12;
-                        this.menu.config.clusterBy = GraphVisualization.ClusterMethod.LABEL;
-                        break;
-                    case 'lr': // Hierarchical: Left-to-right
-                        dagDistance = Math.log10(this.store.config.nodes.length) * 100;
-                        collisionRadius = 12;
-                        break;
-                    case 'radialin': // Radial: Inward
-                        dagDistance = Math.log10(this.store.config.nodes.length) * 100;
-                        collisionRadius = 8;
-                        break;
-                    case 'radialout': // Radial: Outward
-                        dagDistance = Math.log10(this.store.config.nodes.length) * 100;
-                        collisionRadius = 8;
-                        break;
-                    default: // Force layout (default)
-                        dagDistance = 0; // Not applicable for force layout
-                        break;
-                }
-
-                this.graph.dagMode(newLayout);
-
-                // Set dagLevelDistance after setting dagMode
-                if (newLayout !== '') {
-                    this.graph.dagLevelDistance(dagDistance);
-                }
-
-                // Update d3Force collision
-                this.requestedRecenter = true;
-                this.graph.d3Force('collide', d3.forceCollide(collisionRadius));``
-            } catch (error) {
-                console.error('Error updating graph layout:', error);
-            }
-        });
-
-        this.menu.elements.elementCount = this.menuMount.querySelector('.element-count');
-
-        this.menu.elements.viewSchema = this.menuMount.querySelector('#view-schema');
-        this.menu.elements.viewSchema.addEventListener('change', () => {
-            const viewMode = this.menu.elements.viewSchema.checked ?
-                GraphStore.ViewModes.SCHEMA : GraphStore.ViewModes.DEFAULT;
-            this.store.setViewMode(viewMode);
-        });
-
-        this.menu.elements.showLabels = this.menuMount.querySelector('#show-labels');
-        this.menu.elements.showLabels.addEventListener('change', () => {
-            this.menu.config.showLabels = this.menu.elements.showLabels.checked;
-        });
-    }
-
     /**
      * Callback for GraphStore.EventTypes.CONFIG_CHANGE events.
      * @param {GraphConfig} config - The new configuration.
@@ -862,7 +543,7 @@ class GraphVisualization {
                     let distance = Math.log10(this.store.config.nodes.length) * 40;
 
                     // Only apply neighborhood clustering logic if using force layout
-                    if (this.store.config.nodes.length !== 0 && (this.store.viewMode === GraphStore.ViewModes.SCHEMA || this.graph.dagMode() !== '')) {
+                    if (this.store.config.nodes.length !== 0 && (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA || this.graph.dagMode() !== '')) {
                         distance = Math.log10(this.store.config.nodes.length) * 50;
                     } else if (this.graph.dagMode() === '') {
                         distance = link.source.neighborhood === link.target.neighborhood ? distance * 0.5 : distance * 0.8;
@@ -1069,7 +750,7 @@ class GraphVisualization {
                             ctx.fill();
                         }
 
-                        const showLabel = this.menu.config.showLabels ||
+                        const showLabel = this.store.config.showLabels ||
                             node === this.store.config.selectedGraphObject ||
                             node === this.store.config.focusedGraphObject ||
                             this.selectedNodeNeighbors.includes(node) ||
@@ -1077,20 +758,20 @@ class GraphVisualization {
                             this.focusedEdgeNeighbors.includes(node) ||
                             this.selectedEdgeNeighbors.includes(node) ||
                             isFocusedOrHovered ||
-                            this.store.viewMode === GraphStore.ViewModes.SCHEMA;
+                            this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA;
 
                         // Init label
                         ctx.save();
                         ctx.translate(node.x, node.y);
                         const fontSize = 2;
-                        ctx.font = `${this.store.viewMode === GraphStore.ViewModes.DEFAULT ? 'bold' : ''} ${fontSize}px 'Google Sans', Roboto, Arial, sans-serif`;
+                        ctx.font = `${this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT ? 'bold' : ''} ${fontSize}px 'Google Sans', Roboto, Arial, sans-serif`;
 
                         if (!showLabel) {
                             return;
                         }
 
                         let label = node.label;
-                        if (this.store.viewMode === GraphStore.ViewModes.DEFAULT && node.identifiers.length > 0) {
+                        if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT && node.identifiers.length > 0) {
                             label += ` (${node.identifiers.join(', ')})`;
                         }
 
@@ -1130,7 +811,7 @@ class GraphVisualization {
                             textVerticalOffset = -Math.abs(textRect.actualBoundingBoxAscent - textRect.actualBoundingBoxDescent) * 0.25;
                         }
 
-                        if (this.store.viewMode === GraphStore.ViewModes.SCHEMA) {
+                        if (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA) {
                             // "NodeType"
                             ctx.textAlign = 'center';
                             ctx.textBaseline = 'middle';
@@ -1142,7 +823,7 @@ class GraphVisualization {
                                 textVerticalOffset);
 
                             ctx.restore();
-                        } else if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+                        } else if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
                             // "NodeType <b>(identifiers)</b>"
                             // requires two separate drawings
                             ctx.textAlign = 'left';
@@ -1260,7 +941,7 @@ class GraphVisualization {
                             }
 
                             // 5. Always show the label if "Show Labels" is selected
-                            if (this.menu.config.showLabels) {
+                            if (this.store.config.showLabels) {
                                 return true;
                             }
 

--- a/templates/spanner-graph/visualization/spanner-menu.js
+++ b/templates/spanner-graph/visualization/spanner-menu.js
@@ -1,0 +1,447 @@
+/* # Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ */
+
+class SpannerMenu {
+    svg = {
+        bubble: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M580-120q-50 0-85-35t-35-85q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35Zm0-80q17 0 28.5-11.5T620-240q0-17-11.5-28.5T580-280q-17 0-28.5 11.5T540-240q0 17 11.5 28.5T580-200Zm80-200q-92 0-156-64t-64-156q0-92 64-156t156-64q92 0 156 64t64 156q0 92-64 156t-156 64Zm0-80q59 0 99.5-40.5T800-620q0-59-40.5-99.5T660-760q-59 0-99.5 40.5T520-620q0 59 40.5 99.5T660-480ZM280-240q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm0-80q33 0 56.5-23.5T360-400q0-33-23.5-56.5T280-480q-33 0-56.5 23.5T200-400q0 33 23.5 56.5T280-320Zm300 80Zm80-380ZM280-400Z"/></svg>`,
+        table: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H200Zm240-240H200v160h240v-160Zm80 0v160h240v-160H520Zm-80-80v-160H200v160h240Zm80 0h240v-160H520v160ZM200-680h560v-80H200v80Z"/></svg>`,
+        schema: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M160-40v-240h100v-80H160v-240h100v-80H160v-240h280v240H340v80h100v80h120v-80h280v240H560v-80H440v80H340v80h100v240H160Zm80-80h120v-80H240v80Zm0-320h120v-80H240v80Zm400 0h120v-80H640v80ZM240-760h120v-80H240v80Zm60-40Zm0 320Zm400 0ZM300-160Z"/></svg>`,
+    }
+
+    elements = {
+        views: {
+            /**
+             * @type {HTMLElement}
+             */
+            container: null,
+            /**
+             * @type {Array<HTMLElement>}
+             */
+            buttons: [],
+        },
+        layout: {
+            /**
+             * @type {HTMLElement}
+             */
+            container: null,
+            /**
+             * @type {HTMLElement}
+             */
+            title: null,
+            /**
+             * @type {Array<HTMLElement>}
+             */
+            buttons: [],
+            /**
+             * @type {HTMLElement}
+             */
+            content: null,
+        },
+        /**
+         * @type {HTMLElement}
+         */
+        nodeEdgeCount: null,
+        showLabels: {
+            /**
+             * @type {HTMLElement}
+             */
+            container: null,
+            /**
+             * @type {HTMLInputElement}
+             */
+            switch: null,
+        }
+    };
+
+    constructor(inStore, inMount) {
+        this.store = inStore;
+        this.mount = inMount;
+
+        this.scaffold();
+        this.initializeEvents();
+    }
+
+    scaffold() {
+        this.mount.innerHTML = `
+            <style>
+                header {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                }
+                .menu-bar {
+                    align-items: center;
+                    border-bottom: 1px solid #DADCE0;
+                    box-sizing: border-box;
+                    color: #3C4043;
+                    display: flex;
+                    padding: 16px 24px 16px 16px;
+                    width: 100%;
+                    background: #fff;
+                }
+                .menu-item {
+                    display: flex;
+                    margin-right: 16px;
+                }
+                .menu-bar .hidden {
+                    visibility: hidden;
+                }
+                .toggle-container {
+                    display: flex;
+                    align-items: center;
+                    height: 100%;
+                    margin-left: 10px;
+                }
+                .toggle-switch {
+                    position: relative;
+                    display: inline-block;
+                    width: 46px;
+                    height: 24px;
+                    flex-shrink: 0;
+                }
+                .toggle-switch input {
+                    opacity: 0;
+                    width: 0;
+                    height: 0;
+                    margin: 0;
+                    padding: 0;
+                }
+                .hidden .toggle-slider {
+                    transition: 0ms;
+                }
+                .toggle-slider {
+                    position: absolute;
+                    cursor: pointer;
+                    top: 0;
+                    left: 0;
+                    right: 0;
+                    bottom: 0;
+                    background-color: #e9ecef;
+                    transition: .4s;
+                    border-radius: 24px;
+                }
+                .toggle-slider:before {
+                    position: absolute;
+                    content: "";
+                    height: 18px;
+                    width: 18px;
+                    left: 3px;
+                    bottom: 3px;
+                    background-color: white;
+                    transition: .3s;
+                    border-radius: 50%;
+                }
+                input:checked + .toggle-slider {
+                    background-color: #228be6;
+                }
+                input:checked + .toggle-slider:before {
+                    transform: translateX(22px);
+                }
+                .toggle-label {
+                    margin-left: 8px;
+                    color: #202124;
+                    line-height: 24px;
+                }
+                .graph-element-tooltip {
+                    font: 12px 'Google Sans', 'Roboto', sans-serif;
+                    position: absolute;
+                    padding: 4px 8px;
+                    box-sizing: border-box;
+                    pointer-events: none;
+                    transition: opacity 0.2s ease-in-out;
+                    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+                    border-radius: 4px;
+                }
+                
+                /* Ensure .graph-tooltip built-in from force-graph does not interfere */
+                .graph-tooltip {
+                    background: none !important;
+                    border: none !important;
+                    padding: 0 !important;
+                }
+
+                .menu-bar .dropdown {
+                    margin-right: 16px;
+                    position: relative;
+                }
+
+                .dropdown-toggle {
+                    appearance: none;
+                    background: url("data:image/svg+xml;utf8,<svg fill='rgba(73, 80, 87, 1)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>") no-repeat;
+                    background-position: right 10px center;
+                    background-color: white;
+                    padding: 12px 40px 12px 16px;
+                    border: 1px solid #80868B;
+                    border-radius: 4px;
+                    color: #3C4043;
+                    cursor: pointer;
+                    font-size: 16px;
+                    text-align: left;
+                    width: 260px;
+                }
+                
+                .dropdown-toggle.disabled {
+                    background: url("data:image/svg+xml;utf8,<svg fill='rgba(73, 80, 87, .6)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>") no-repeat;
+                    background-position: right 10px center;
+                    background-color: #EBEBE4;
+                    border: 1px solid #EBEBE4;
+                    cursor: default;
+                }
+
+                .arrow-down {
+                    margin-left: 5px;
+                    font-size: 10px;
+                }
+
+                .menu-bar .dropdown .dropdown-content {
+                    display: none;
+                    position: absolute;
+                    background-color: #fff;
+                    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+                    z-index: 1;
+                    top: 100%;
+                    left: 0;
+                    padding: 8px 0;
+                }
+
+                .menu-bar .dropdown:hover .dropdown-content:not(.disabled) {
+                    display: block;
+                }
+
+                .menu-bar .dropdown .dropdown-item {
+                    color: #495057;
+                    padding: 8px 32px 8px 8px;
+                    text-decoration: none;
+                    display: flex;
+                    align-items: center;
+                }
+
+                .menu-bar .dropdown .dropdown-item.selected {
+                    background: url("data:image/svg+xml;utf8,<svg height='24' viewBox='0 0 24 24' width='24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M2 6L5 9L10 3' stroke='rgba(73, 80, 87, 1)' stroke-width='2' stroke-linecap='square'/></svg>") no-repeat;
+                    background-position: left 15px top 100%;
+                }
+
+                .menu-bar .dropdown .dropdown-item:hover {
+                    background-color: #f8f9fa;
+                }
+
+                .checkmark {
+                    width: 20px;
+                    margin-right: 8px;
+                }
+
+                .element-count {
+                    color: #000;
+                    display: flex;
+                    flex: 1;
+                    font-weight: 500;
+                }
+
+                .item-text {
+                    flex: 1;
+                }
+                
+                #graph-tools {
+                    position: absolute;
+                    bottom: 16px;
+                    right: 16px;
+                }
+        
+                #graph-tools button {
+                    display: block;
+                    width: 40px;
+                    height: 40px;
+                    background-color: transparent;
+                    border: none;
+                    border-radius: 20px;
+                    cursor: pointer;
+                }
+        
+                #graph-tools button:hover {
+                    background-color: rgba(26, 115, 232, .08);
+                }
+                
+                .view-toggle-group {
+                    display: flex;
+                    align-items: center;
+                    margin-right: 16px;
+                    border: 1px solid #DADCE0;
+                    border-radius: 4px;
+                    overflow: hidden;
+                }
+
+                .view-toggle-group .view-toggle-button {
+                    background: none;
+                    border: none;
+                    padding: 8px;
+                    cursor: pointer;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    border-radius: 0;
+                }
+
+                .view-toggle-button:not(:last-child) {
+                    border-right: 1px solid #DADCE0;
+                }
+
+                .view-toggle-button:hover {
+                    background-color: rgba(0, 0, 0, 0.04);
+                }
+
+                .view-toggle-button.active {
+                    background-color: #E8F0FE;
+                }
+
+                .view-toggle-button.active svg {
+                    fill: #1A73E8;
+                }
+            </style>
+            <div class="menu-bar">
+                <div class="view-toggle-group">
+                    <button class="view-toggle-button active" id="view-default" data-view="${GraphConfig.ViewModes.DEFAULT.description}" title="Graph View">
+                        ${this.svg.bubble}
+                    </button>
+                    <button class="view-toggle-button" id="view-table" data-view="${GraphConfig.ViewModes.TABLE.description}" title="Table View">
+                        ${this.svg.table}
+                    </button>
+                    <button class="view-toggle-button" id="view-schema" data-view="${GraphConfig.ViewModes.SCHEMA.description}" title="Schema View">
+                        ${this.svg.schema}
+                    </button>
+                </div>
+                
+                <div class="dropdown">
+                    <button class="dropdown-toggle">
+                        Force layout
+                    </button>
+                    <div class="dropdown-content">
+                        <a href="#" class="dropdown-item selected" data-layout="${GraphConfig.LayoutModes.FORCE.description}">
+                            <span class="checkmark"></span>
+                            <span class="item-text">Force layout</span>
+                        </a>
+                        <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.TOP_DOWN.description}">
+                            <span class="checkmark"></span>
+                            <span class="item-text">Hierarchical: Top down</span>
+                        </a>
+                        <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.LEFT_RIGHT.description}">
+                            <span class="checkmark"></span>
+                            <span class="item-text">Hierarchical: Left-to-right</span>
+                        </a>
+                        <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.RADIAL_IN.description}">
+                            <span class="checkmark"></span>
+                            <span class="item-text">Radial: Inward</span>
+                        </a>
+                        <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.RADIAL_OUT.description}">
+                            <span class="checkmark"></span>
+                            <span class="item-text">Radial: Outward</span>
+                        </a>
+                    </div>
+                </div>
+                
+                <div class="element-count">
+                    ${this.store.config.nodes.length} nodes, ${this.store.config.edges.length} edges
+                </div>
+                
+                <div class="toggle-container" id="show-labels-container">
+                    <label class="toggle-switch">
+                        <input id="show-labels" type="checkbox">
+                        <span class="toggle-slider"></span>
+                    </label>
+                    <span class="toggle-label">Show labels</span>
+                </div>
+            </div>`;
+
+        this.elements.views.container = this.mount.querySelector('.view-toggle-group');
+        this.elements.views.default = this.mount.querySelector('#view-default');
+        this.elements.views.table = this.mount.querySelector('#view-table');
+        this.elements.views.schema = this.mount.querySelector('#view-schema');
+
+        this.elements.layout.container = this.mount.querySelector('.dropdown');
+        this.elements.layout.buttons = this.mount.querySelectorAll('.dropdown-item');
+        this.elements.layout.title = this.mount.querySelector('.dropdown-toggle');
+        this.elements.layout.content = this.mount.querySelector('.dropdown-content');
+
+        this.elements.nodeEdgeCount = this.mount.querySelector('.element-count');
+        this.elements.showLabels.container = this.mount.querySelector('#show-labels-container');
+        this.elements.showLabels.switch = this.mount.querySelector('#show-labels');
+    }
+
+    initializeEvents() {
+        // View Modes
+        this.elements.views.buttons = this.mount.querySelectorAll('.view-toggle-button');
+        this.elements.views.buttons.forEach(button => {
+            button.addEventListener('click', () => {
+                this.store.setViewMode(GraphConfig.ViewModes[button.dataset.view]);
+            });
+        });
+
+        this.store.addEventListener(GraphStore.EventTypes.VIEW_MODE_CHANGE, (viewMode) => {
+            this.elements.views.buttons.forEach(button => {
+               if (button.dataset.view === viewMode.description) {
+                    button.classList.add('active');
+               } else {
+                    button.classList.remove('active');
+               }
+            });
+
+            switch (viewMode) {
+                case GraphConfig.ViewModes.DEFAULT:
+                    // visibility: [view modes] [layout dropdown] [node-edge count] [show labels]
+                    this.elements.layout.container.classList.remove('hidden');
+                    this.elements.nodeEdgeCount.classList.remove('hidden');
+                    this.elements.showLabels.container.classList.remove('hidden');
+                    break;
+                case GraphConfig.ViewModes.TABLE:
+                case GraphConfig.ViewModes.SCHEMA:
+                default:
+                    // visibility: [view modes]
+                    this.elements.layout.container.classList.add('hidden');
+                    this.elements.nodeEdgeCount.classList.add('hidden');
+                    this.elements.showLabels.container.classList.add('hidden');
+                    break;
+            }
+        });
+
+        // Layouts
+        this.elements.layout.content.addEventListener('click', e => {
+            e.preventDefault();
+
+            const layoutButton = e.target.closest('.dropdown-item');
+            if (!layoutButton) return;
+
+            this.store.setLayoutMode(GraphConfig.LayoutModes[layoutButton.dataset.layout]);
+        });
+
+        this.store.addEventListener(GraphStore.EventTypes.LAYOUT_MODE_CHANGE, (layoutMode) => {
+            this.elements.layout.buttons.forEach(button => {
+                if (button.dataset.layout === layoutMode.description) {
+                    button.classList.add('selected');
+                    this.elements.layout.title.textContent = button.textContent;
+                } else {
+                    button.classList.remove('selected');
+                }
+            });
+        });
+
+        // Show Labels
+        this.elements.showLabels.switch.addEventListener('change', () => {
+            this.store.showLabels(this.elements.showLabels.switch.checked);
+        });
+
+        this.store.addEventListener(GraphStore.EventTypes.SHOW_LABELS, (visible) => {
+           this.elements.showLabels.switch.checked = visible;
+        });
+    }
+}

--- a/templates/spanner-graph/visualization/spanner-sidebar.js
+++ b/templates/spanner-graph/visualization/spanner-sidebar.js
@@ -277,7 +277,7 @@ class SidebarConstructor {
                     position: absolute;
                     left: 16px;
                     top: 16px;
-                    max-height: 80%;
+                    max-height: calc(100% - 2rem);
                     overflow-y: auto;
                     display: flex;
                     flex-direction: column;
@@ -912,6 +912,11 @@ class Sidebar {
                 // Clean up sidebar
                 this.mount.innerHTML = '';
                 this.mount.textContent = '';
+
+                if (viewMode === GraphConfig.ViewModes.TABLE) {
+                    return;
+                }
+
                 this.constructSidebar();
             });
 

--- a/templates/spanner-graph/visualization/spanner-sidebar.js
+++ b/templates/spanner-graph/visualization/spanner-sidebar.js
@@ -259,7 +259,7 @@ class SidebarConstructor {
                 this.neighbors();
                 this.properties();
             }
-        } else if (this.store.viewMode === GraphStore.ViewModes.SCHEMA) {
+        } else if (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA) {
             this.schemaNodes();
             this.schemaEdges();
         }
@@ -598,7 +598,7 @@ class SidebarConstructor {
             if (selectedObject instanceof Node) {
                 content.appendChild(this._nodeChipHtml(selectedObject));
 
-                if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+                if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
                     const property = document.createElement('span');
                     property.className = 'selected-object-label';
                     property.textContent = selectedObject.identifiers.join(', ');
@@ -627,7 +627,7 @@ class SidebarConstructor {
 
         if (selectedObject) {
             selectedObjectTitle();
-        } else if (this.store.viewMode === GraphStore.ViewModes.SCHEMA) {
+        } else if (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA) {
             // Show a high level overview of the schema
             // when no graph object is selected
             schemaTitle();
@@ -693,7 +693,7 @@ class SidebarConstructor {
 
         let labelWrapClass = '';
         let valueWrapClass = '';
-        if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+        if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
              labelWrapClass = 'property-label-wrap';
              valueWrapClass = 'property-value-wrap';
         }
@@ -747,7 +747,7 @@ class SidebarConstructor {
                 neighborDiv.appendChild(this._nodeChipHtml(neighbor, true));
 
                 // Node Neighbor ID
-                if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+                if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
                     const idSpan = document.createElement('span');
                     idSpan.className = 'neighbor-id';
                     idSpan.textContent = neighbor.identifiers.join(', ');
@@ -799,7 +799,7 @@ class SidebarConstructor {
                 value.className = 'edge-neighbor-node';
                 value.appendChild(this._nodeChipHtml(neighbor, true));
 
-                if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+                if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
                     const neighborIdElement = document.createElement('span');
                     neighborIdElement.className = 'neighbor-id';
                     neighborIdElement.textContent = neighbor.identifiers.join(', ');
@@ -882,7 +882,7 @@ class Sidebar {
         const sidebar = this.mount;
         sidebar.className = 'sidebar';
 
-        if (this.store.viewMode === GraphStore.ViewModes.DEFAULT) {
+        if (this.store.config.viewMode === GraphConfig.ViewModes.DEFAULT) {
             if (!this.selectedObject) {
                 sidebar.style.display = 'none';
             } else {

--- a/templates/spanner-graph/visualization/spanner-table.js
+++ b/templates/spanner-graph/visualization/spanner-table.js
@@ -1,0 +1,639 @@
+/**
+ * Copyright 2024 Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * SpannerTable - A class to render a table view of graph data.
+ */
+class SpannerTable {
+    svg = {
+        up: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M480-528 296-344l-56-56 240-240 240 240-56 56-184-184Z"/></svg>`,
+        down: `<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M480-344 240-584l56-56 184 184 184-184 56 56-240 240Z"/></svg>`
+    };
+
+    /**
+     * @type {HTMLElement}
+     */
+    mount = null;
+    /**
+     * @type {HTMLElement}
+     */
+    menuMount = null;
+
+    /**
+     * @type {GraphStore}
+     */
+    store = null;
+
+    /**
+     * [
+     *     [{column_1_data}, {column_2_data}, {column_3_data}, ...],
+     *     [{column_1_data}, {column_2_data}, {column_3_data}, ...],
+     *     ...
+     * ]
+     * @type {Array<Array<Object>>}
+     */
+    rows = [];
+
+    currentPage = 0;
+    rowsPerPage = 0;
+    pageLengths = [50, 100, 200]
+
+    /**
+     * Creates an instance of SpannerTable.
+     * @param {GraphStore} store
+     * @param {HTMLElement} mount
+     * @param {HTMLElement} menuMount
+     */
+    constructor(store, mount, menuMount) {
+        this.store = store;
+        this.mount = mount;
+        this.menuMount = menuMount;
+        this.currentPage = 0;
+        this.rowsPerPage = this.pageLengths[0];
+        this.expandedRows = new Set(); // Track expanded rows
+
+        this.initializeEvents();
+        this.parseQueryResultToRows();
+        this.render();
+    }
+
+    initializeEvents() {
+        const debounce = (callback, timeout = 300) => {
+            let timer = 0;
+            return (...args) => {
+                window.clearTimeout(timer);
+                timer = window.setTimeout(() => {
+                    callback.apply(this, args);
+                }, timeout);
+            }
+        }
+
+        const fullscreenMount = this.mount.parentElement.parentElement;
+        window.addEventListener('fullscreenchange', debounce((e) => {
+            if (fullscreenMount !== e.target) {
+                return;
+            }
+
+            if (!document.fullscreenElement) {
+                this.mount.style.width = '100%';
+                this.mount.style.height = '616px';
+            } else {
+                const height = window.innerHeight - this.menuMount.offsetHeight;
+                this.mount.style.width = window.innerWidth + 'px';
+                this.mount.style.height = height + 'px';
+            }
+        }));
+    }
+
+    /**
+     * Prepare query result data to be rendered in the table.
+     *
+     * queryResult is formatted as such:
+     * {
+     *     field_string_A: [{data_1}, {data_2}, {data_3}]
+     *     field_string_B: [{data_1}, {data_2}, {data_3}]
+     * }
+     * We want it transformed to an array of rows that matches
+     * the presentation of the table:
+     * [
+     *     // field A   field B   field C
+     *     [{data_1},  {data_1}, {data_1}]
+     *     [{data_2},  {data_2}, {data_2}]
+     *     [{data_3},  {data_3}, {data_3}]
+     * ]
+     */
+    parseQueryResultToRows() {
+        if (!this.store || !this.store.config) {
+            this.handleError('Cannot generate table: sorry, something went wrong');
+            return;
+        }
+
+        if (!this.store.config.queryResult || typeof this.store.config.queryResult !== 'object') {
+            this.handleError('Cannot generate table: query result not found or malformed');
+            console.error('Cannot generate table: query result not found or malformed', this.store.config.queryResult);
+            return;
+        }
+
+        try {
+            this.rows = [];
+
+            const fields = Object.keys(this.store.config.queryResult);
+
+            const rowCount = fields.reduce((max, field) => {
+                const rows = this.store.config.queryResult[field];
+                return rows instanceof Array ? Math.max(max, rows.length) : max;
+            }, 0);
+
+            for (let i = 0; i < rowCount; i++) {
+                const row = [];
+                for (const field of fields) {
+                    if (i < this.store.config.queryResult[field].length) {
+                        row.push(this.store.config.queryResult[field][i]);
+                    } else {
+                        row.push({})
+                    }
+                }
+                this.rows.push(row);
+            }
+        } catch (error) {
+            this.handleError('Cannot generate table: sorry, something went wrong');
+            console.error('Error generating table:', error);
+        }
+    }
+
+    render() {
+        if (!this.store || !this.store.config) {
+            this.handleError('Cannot generate table: sorry, something went wrong');
+            return;
+        }
+
+        if (!this.store.config.queryResult || typeof this.store.config.queryResult !== 'object') {
+            this.handleError('Cannot generate table: query result not found or malformed');
+            console.error('Cannot generate table: query result not found or malformed', this.store.config.queryResult);
+            return;
+        }
+
+        this.mount.innerHTML = `
+            <style>
+                /* Add styles for the container itself */
+                #${this.mount.id} {
+                    width: 100%;
+                    max-width: 100%;
+                    height: 616px;
+                    overflow: scroll;
+                    display: flex;
+                    flex-direction: column;
+                }
+            
+                #${this.mount.id} table.spanner-table {
+                    table-layout: fixed !important;
+                    border-collapse: separate;
+                    font-family: 'Google Sans', Roboto, Arial, sans-serif;
+                    width: max-content;
+                    min-width: 100%;
+                    margin-bottom: 0;
+                }
+                
+                .table-error {
+                    padding: 2rem;
+                    color: #d93025;
+                    background: #fce8e6;
+                    border-radius: 4px;
+                    margin: 1rem;
+                    font-family: 'Google Sans', Roboto, Arial, sans-serif;
+                }
+                
+                .table-empty-state {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    justify-content: center;
+                    padding: 3rem;
+                    color: #5f6368;
+                }
+            
+                .spanner-table-wrapper {
+                    overflow-x: auto;
+                    width: 100%;
+                    position: relative;
+                    max-width: 100%;
+                    display: block;
+                    overflow-y: scroll;
+                    flex: 1;
+                    background-color: #FBFDFF;
+                }
+            
+                .spanner-table th, .spanner-table td {
+                    border-bottom: 1px solid #ddd;
+                    text-align: left;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    vertical-align: middle;
+                    padding: 0 0 0 8px;
+                }
+            
+                .spanner-table th {
+                    background-color: #f2f2f2;
+                    position: sticky;
+                    top: 0;
+                    font-weight: 500;
+                    color: rgb(112, 112, 112);
+                    text-align: left !important;
+                    z-index: 9;
+                }
+            
+                div.spanner-table-wrapper table.spanner-table tbody tr {
+                    background-color: #fff;
+                }
+                
+                div.spanner-table-wrapper table.spanner-table tr {
+                    height: 1.75rem;
+                    padding: 0;
+                }
+            
+                div.spanner-table-wrapper table.spanner-table tbody tr:hover {
+                    background-color: #f5f5f5;
+                }
+                
+                table.spanner-table thead tr th.expand-column.header, 
+                table.spanner-table tbody tr td.expand-column {
+                    padding: 0 !important;
+                    box-sizing: content-box !important;
+                    min-width: 32px !important;
+                    max-width: 32px !important;
+                    width: 32px !important;
+                }
+            
+                table.spanner-table tbody tr td.expand-column {
+                    position: sticky;
+                    right: -1px;
+                    background: white;
+                    text-align: center;
+                    z-index: 1;
+                    vertical-align: top !important;
+                }
+            
+                table.spanner-table tbody tr td.expand-column::before {
+                    content: '';
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    height: 100%;
+                    border-left: 1px solid #ddd;
+                }
+            
+                .expand-icon {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                
+                    cursor: pointer;
+                    opacity: 0.7;
+                    line-height: 0;
+                    height: 1.75rem;
+                    
+                }
+            
+                .expand-icon:hover {
+                    opacity: 1;
+                }
+            
+                .cell-content {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    text-align: left;
+                    line-height: 1.2rem;
+                }
+            
+                .expanded .cell-content {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                    max-height: none;
+                    word-break: break-word;
+                }
+            
+                .expanded td {
+                    white-space: normal;
+                    max-height: none;
+                    overflow: visible;
+                }
+            
+                .pagination-controls {
+                    display: flex;
+                    justify-content: flex-end;
+                    align-items: center;
+                    padding: 16px;
+                    color: rgb(112, 112, 112);
+                    font-size: 14px;
+                    border-top: 1px solid #ddd;
+                }
+            
+                .rows-per-page {
+                    margin-right: 32px;
+                }
+            
+                .rows-per-page select {
+                    margin: 0 8px;
+                    padding: 4px;
+                }
+            
+                .pagination-range {
+                    margin-right: 32px;
+                }
+            
+                .pagination-arrows {
+                    display: flex;
+                    gap: 8px;
+                }
+            
+                .pagination-arrow {
+                    cursor: pointer;
+                    padding: 4px;
+                    opacity: 0.7;
+                    background-color: #fff;
+                    border: none;
+                }
+            
+                .pagination-arrow:hover {
+                    opacity: 1;
+                }
+            
+                .pagination-arrow[disabled] {
+                    opacity: 0.3;
+                    cursor: default;
+                }
+            
+                td {
+                    position: relative;
+                }
+            </style>
+            <div class="spanner-table-wrapper">
+                <div class="table-error hidden"></div>
+                <div class="table-empty-state hidden">
+                    <p>No data available to display</p>
+                </div>
+                <table class="spanner-table"></table>
+            </div>
+        `;
+
+        if (this.rows.length === 0) {
+            this.mount.querySelector('.table-empty-state').classList.remove('hidden');
+            return;
+        }
+
+        const table = this.mount.querySelector('.spanner-table');
+
+        const thead = this.createTableHeader();
+        if (thead instanceof HTMLElement) {
+            table.appendChild(thead);
+        }
+
+        const tbody = this.createTableBody();
+        if (tbody instanceof HTMLElement) {
+            table.appendChild(tbody);
+        }
+
+        this.createPaginationControls();
+    }
+
+    handleError(message, type = 'error') {
+        const errorContainer = this.mount.querySelector('.table-error');
+        const tableWrapper = this.mount.querySelector('.spanner-table');
+
+        errorContainer.classList.remove('hidden');
+        errorContainer.textContent = message;
+        tableWrapper.classList.add('hidden');
+    }
+
+    /**
+     * @returns {HTMLElement} The table header element.
+     */
+    createTableHeader() {
+        if (!this.store || !this.store.config) {
+            console.error('Cannot generate table: requires store and config');
+            return null;
+        }
+
+        if (!this.store.config.queryResult || typeof this.store.config.queryResult !== 'object') {
+            console.error('Cannot generate table: query result not found or malformed', this.store.config.queryResult);
+            return null;
+        }
+
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+
+        Object.keys(this.store.config.queryResult).forEach(field => {
+            let header = field;
+            if (typeof field !== 'string') {
+                console.warn('Table header error: expecting field to be a string', field);
+                header = 'column';
+            }
+
+            const th = document.createElement('th');
+            th.textContent = header;
+            headerRow.appendChild(th);
+        });
+
+        // Add expand column header
+        const expandHeader = document.createElement('th');
+        expandHeader.className = 'expand-column header';
+        headerRow.appendChild(expandHeader);
+
+        thead.appendChild(headerRow);
+        return thead;
+    }
+
+    /**
+     * Formats cell content based on the data type and header configuration
+     * @param {Object} cellData - The data to format
+     * @param {number} rowIndex - The absolute index of this row
+     * @returns {{truncated: boolean, content: string}} Formatted string representation
+     */
+    formatCellContent(cellData, rowIndex) {
+        let content = '';
+        let truncated = false;
+
+        if (cellData === null || cellData === undefined || cellData === '') {
+            return {content, truncated};
+        }
+
+        try {
+            if (this.expandedRows.has(rowIndex)) {
+                switch (typeof cellData) {
+                    case 'string':
+                        content = cellData;
+                        break;
+                    case 'object':
+                        content = JSON.stringify(cellData, null, 4) || '{}';
+                        break;
+                    default:
+                        content = String(cellData);
+                }
+            } else {
+                switch (typeof cellData) {
+                    case 'string':
+                        content = cellData;
+                        break;
+                    case 'object':
+                        content = JSON.stringify(cellData) || '{}';
+                        break;
+                    default:
+                        content = String(cellData);
+                }
+
+                truncated = content.length > 80;
+                if (truncated) {
+                    content = content.substring(0, 77) + '...';
+                }
+            }
+
+        } catch (error) {
+            console.warn(`Error formatting cell data:`, {error, cellData, rowIndex});
+            content = '<Error: check console>';
+        }
+
+        return {content, truncated};
+    }
+
+    /**
+     * @returns {HTMLElement} The table body element.
+     */
+    createTableBody() {
+        const tbody = document.createElement('tbody');
+        if (!this.rows instanceof Array) {
+            return tbody;
+        }
+
+        const start = this.currentPage * this.rowsPerPage;
+        const end = start + this.rowsPerPage;
+        const pageData = this.rows.slice(start, end);
+        pageData.forEach((rowData, rowIndex) => {
+            const absoluteRowIndex = start + rowIndex; // Calculate absolute row index
+            const row = document.createElement('tr');
+            let showExpansionArrow = false;
+
+            rowData.forEach((cellData, index) => {
+                const td = document.createElement('td');
+                const contentDiv = document.createElement('div');
+                contentDiv.className = 'cell-content';
+                const {content, truncated} = this.formatCellContent(cellData, absoluteRowIndex);
+                contentDiv.textContent = content;
+                td.appendChild(contentDiv);
+                row.appendChild(td);
+
+                showExpansionArrow = showExpansionArrow || truncated;
+            });
+
+            // Add expand column
+            const expandTd = document.createElement('td');
+            expandTd.className = 'expand-column';
+            if (showExpansionArrow) {
+                const expandIcon = document.createElement('span');
+                expandIcon.innerHTML = this.expandedRows.has(absoluteRowIndex) ? this.svg.down : this.svg.up;
+                expandIcon.className = 'expand-icon';
+                expandIcon.onclick = (e) => {
+                    e.stopPropagation();
+                    const isExpanded = this.expandedRows.has(absoluteRowIndex);
+                    if (isExpanded) {
+                        this.expandedRows.delete(absoluteRowIndex);
+                        expandIcon.innerHTML = this.svg.up;
+                    } else {
+                        this.expandedRows.add(absoluteRowIndex);
+                        expandIcon.innerHTML = this.svg.down;
+                    }
+                    row.classList.toggle('expanded', !isExpanded);
+                    this.updateRowContent(row, rowData, absoluteRowIndex);
+                };
+                expandTd.appendChild(expandIcon);
+            }
+            row.appendChild(expandTd);
+
+            if (this.expandedRows.has(absoluteRowIndex)) {
+                row.classList.add('expanded');
+            }
+
+            tbody.appendChild(row);
+        });
+
+        return tbody;
+    }
+
+    /**
+     * Updates the content of a row when expansion state changes
+     * @param {HTMLElement} row - The row element to update
+     * @param {Array} rowData - The data for this row
+     * @param {number} rowIndex - The absolute index of this row
+     */
+    updateRowContent(row, rowData, rowIndex) {
+        if (!(row instanceof HTMLElement)) {
+            return;
+        }
+
+        const cells = Array.from(row.children).slice(0, -1); // Exclude expand column
+        for (let i = 0; i < cells.length; i++) {
+            const contentDiv = cells[i].querySelector('.cell-content');
+            if (!contentDiv) {
+                return;
+            }
+
+            contentDiv.textContent = this.formatCellContent(rowData[i], rowIndex).content;
+        }
+    }
+
+    /**
+     * Creates pagination controls.
+     */
+    createPaginationControls() {
+        const pagination = document.createElement('div');
+        pagination.className = 'pagination-controls';
+
+        // Rows per page dropdown
+        const rowsPerPage = document.createElement('div');
+        rowsPerPage.className = 'rows-per-page';
+        const select = document.createElement('select');
+        this.pageLengths.forEach(value => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = value;
+            option.selected = value === this.rowsPerPage;
+            select.appendChild(option);
+        });
+        select.addEventListener('change', (e) => {
+            this.rowsPerPage = parseInt(e.target.value);
+            this.currentPage = 0; // Reset to first page when changing page size
+            this.render();
+        });
+
+        rowsPerPage.appendChild(document.createTextNode('Rows per page:'));
+        rowsPerPage.appendChild(select);
+
+        // Pagination range
+        const range = document.createElement('div');
+        range.className = 'pagination-range';
+        const start = this.currentPage * this.rowsPerPage + 1;
+        const end = Math.min((this.currentPage + 1) * this.rowsPerPage, this.rows.length);
+        range.textContent = `${start}–${end} of ${this.rows.length}`;
+
+        // Pagination arrows
+        const arrows = document.createElement('div');
+        arrows.className = 'pagination-arrows';
+
+        const createArrow = (text, onClick, disabled) => {
+            const arrow = document.createElement('button');
+            arrow.className = 'pagination-arrow';
+            arrow.textContent = text;
+            arrow.onclick = onClick;
+            if (disabled) arrow.setAttribute('disabled', '');
+            return arrow;
+        };
+
+        arrows.appendChild(createArrow('⟨⟨', () => this.goToPage(0), this.currentPage === 0));
+        arrows.appendChild(createArrow('⟨', () => this.goToPage(this.currentPage - 1), this.currentPage === 0));
+        arrows.appendChild(createArrow('⟩', () => this.goToPage(this.currentPage + 1), end >= this.rows.length));
+        arrows.appendChild(createArrow('⟩⟩', () => this.goToPage(Math.floor(this.rows.length / this.rowsPerPage)), end >= this.rows.length));
+
+        pagination.appendChild(rowsPerPage);
+        pagination.appendChild(range);
+        pagination.appendChild(arrows);
+        this.mount.appendChild(pagination);
+    }
+
+    goToPage(page) {
+        this.currentPage = page;
+        this.render();
+    }
+}

--- a/templates/template-spannergraph.html
+++ b/templates/template-spannergraph.html
@@ -33,6 +33,7 @@ limitations under the License.
         {{ graph_content | safe }}
         {{ store_content | safe }}
         {{ sidebar_content | safe }}
+        {{ table_content | safe }}
         {{ server_content | safe }}
         {{ app_content | safe }}
 

--- a/templates/template-spannergraph.html
+++ b/templates/template-spannergraph.html
@@ -29,6 +29,7 @@ limitations under the License.
         {{ node_content | safe }}
         {{ edge_content | safe }}
         {{ config_content | safe }}
+        {{ menu_content | safe }}
         {{ graph_content | safe }}
         {{ store_content | safe }}
         {{ sidebar_content | safe }}


### PR DESCRIPTION
## Summary
Adds table visualization for query results and refactors UI components for better maintainability.

## Key Changes
- Add table view with pagination, expandable rows, and configurable page sizes
- Extract menu into standalone component with view mode toggles (Graph/Table/Schema)

## Fixes
- Schema graph was trying to dereference a null pointer when an invalid schema object was pressent
- The edge length heuristic in schema view was checking the amount of nodes and edges in the regular graph. This now checks the nodes and edges in the schema graph and includes a minimum length to prevent the graph from being too closely clustered together.

## Preview
https://github.com/user-attachments/assets/02d95cd2-c4d7-4a6b-aa3c-2d923fd316ce

The first query loads data that can be presented as a default graph, table, and schema. The application defaults to the graph.

The second query returns data that can only be presented as a table and schema. The application defaults to the table.

The third query returns data that can only be presented as a table.
