### PR TITLE
Improve GCP authentication user experience

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="spanner-graph-notebook",
-    version="v1.0.8",
+    version="v1.0.9",
     packages=find_packages(),
     install_requires=[
         "networkx", "numpy", "google-cloud-spanner", "ipython",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         "networkx", "numpy", "google-cloud-spanner", "ipython",
-        "ipywidgets", "notebook", "requests", "portpicker"
+        "ipywidgets", "notebook", "requests", "portpicker",
+        "pydata-google-auth"
     ],
     include_package_data=True,
     description='Visually query Spanner Graph data in notebooks.',

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -27,13 +27,19 @@ from google.cloud import spanner
 from google.cloud.spanner_v1 import JsonObject
 from google.api_core.client_options import ClientOptions
 from google.cloud.spanner_v1.types import StructType, TypeCode, Type
+import pydata_google_auth
 
+def _get_default_credentials_with_project():
+    return pydata_google_auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"], use_local_webserver=False)
 
 class SpannerDatabase:
     """The spanner class holding the database connection"""
     def __init__(self, project_id: str, instance_id: str,
                  database_id: str) -> None:
-        self.client = spanner.Client(project=project_id, client_options=ClientOptions(quota_project_id=project_id))
+        credentials, _ = _get_default_credentials_with_project()
+        self.client = spanner.Client(
+            project=project_id, credentials=credentials, client_options=ClientOptions(quota_project_id=project_id))
         self.instance = self.client.instance(instance_id)
         self.database = self.instance.database(database_id)
 


### PR DESCRIPTION
## Changes
- Spanner client initialization uses pydata-google-auth credentials
- Bumped version from v1.0.8 to v1.0.9

Previously, users needed to run a separate `!gcloud auth login` cell in their notebooks to authenticate. 
By using pydata-google-auth, we now handle authentication directly in Python code, providing a more 
streamlined experience for notebook users. 