### PR TITLE
build: make visualization module generic

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -71,7 +71,7 @@ class SpannerApp {
         table: null
     };
 
-    constructor({id, port, project, instance, database, mock, mount, query}) {
+    constructor({id, port, params, mount, query}) {
         this.id = id;
         this.lastQuery = query;
 
@@ -83,7 +83,7 @@ class SpannerApp {
 
         this.scaffold();
 
-        this.server = new GraphServer(port, project, instance, database, mock);
+        this.server = new GraphServer(port, params);
         this.server.query(query)
             .then(data => {
                 if (!data) {

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -284,6 +284,7 @@ class SpannerApp {
                     <div id="sidebar-${this.id}"></div>
                     <div id="table-${this.id}" class="hidden"></div>
                 </div>
+                <p><b>Hello</b></p>
             </div>
         `;
 

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -284,7 +284,6 @@ class SpannerApp {
                     <div id="sidebar-${this.id}"></div>
                     <div id="table-${this.id}" class="hidden"></div>
                 </div>
-                <p><b>Hello</b></p>
             </div>
         `;
 

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -77,7 +77,7 @@ class SpannerApp {
 
         // mount must be valid
         if (!mount) {
-            throw Error("Must have a valid HTML element to mount the app");
+            throw Error('Must have a valid HTML element to mount the app');
         }
         this.mount = mount;
 

--- a/frontend/src/graph-server.js
+++ b/frontend/src/graph-server.js
@@ -34,7 +34,7 @@ class GraphServer {
         }
     }
 
-    constructor(port, project, instance, database, mock) {
+    constructor(port, params) {
         let numericalPort = port;
         if (typeof numericalPort !== 'number') {
             numericalPort = Number.parseInt(numericalPort);
@@ -46,19 +46,13 @@ class GraphServer {
         }
 
         this.port = numericalPort;
-        this.project = project;
-        this.instance = instance;
-        this.database = database;
-        this.mock = mock;
+        this.params = params
     }
 
     query(queryString) {
         const request = {
             query: queryString,
-            project: this.project,
-            instance: this.instance,
-            database: this.database,
-            mock: this.mock
+            params: this.params
         };
 
         this.isFetching = true;

--- a/frontend/src/graph-server.js
+++ b/frontend/src/graph-server.js
@@ -22,6 +22,13 @@ class GraphServer {
         postQuery: '/post_query',
     };
 
+    /**
+     * Contains parameters needed to create the database object; passed to Python when running a query.
+     * @type {string}
+     */
+    params = null;
+
+
     buildRoute(endpoint) {
         const hostname = window.location.hostname;
 

--- a/frontend/src/graph-server.js
+++ b/frontend/src/graph-server.js
@@ -58,7 +58,7 @@ class GraphServer {
         this.isFetching = true;
 
         if (typeof google !== 'undefined') {
-            return google.colab.kernel.invokeFunction('spanner.Query', [], request)
+            return google.colab.kernel.invokeFunction('graph_visualization.Query', [], request)
                 .then(result => result.data['application/json'])
                 .finally(() => this.isFetching = false);
         }

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -75,10 +75,7 @@ limitations under the License.
                     id: `{{ id }}`,
                     mount: document.querySelector('div.mount-{{ id }}'),
                     port: `{{ port }}`,
-                    project: `{{ project }}`,
-                    instance: `{{ instance }}`,
-                    database: `{{ database }}`,
-                    mock: `{{ mock }}` === 'True',
+                    params: `{{ params }}`,
                     query: `{{ query }}`,
                 }
             );

--- a/frontend/static/test.html
+++ b/frontend/static/test.html
@@ -67,13 +67,15 @@ limitations under the License.
             window.onCustomEvent('page ready');
         }
 
-        const id = 'spanner-test';
-        const project = 'project-foo';
-        const instance = 'instance-foo';
-        const database = 'database-foo';
         const mount = document.querySelector('.mount-spanner-test');
+        params = {
+            'project': 'project-foo',
+            'instance': 'instance-foo',
+            'database': 'database-foo',
+            'mock': true
+        }
         window.app = new SpannerApp({
-            id, project, instance, database, mount, mock: true, query: '', url: ''
+            id: 'spanner-test', port:'', params:params, mount:mount, query: ''
         });
     });
 </script>

--- a/frontend/tests/unit/graph-server.test.ts
+++ b/frontend/tests/unit/graph-server.test.ts
@@ -28,20 +28,23 @@ describe('GraphServer', () => {
         mockFetch.mockClear();
         graphServer = new GraphServer(
             8000,
-            'test-project',
-            'test-instance',
-            'test-database',
-            false
+            {'project': 'test-project',
+             'instance': 'test-instance',
+             'database': 'test-database',
+             'mock': false
+            }
         );
     });
 
     describe('constructor', () => {
         it('should initialize with the default variables', () => {
            expect(graphServer.port).toBe(8000);
-           expect(graphServer.project).toBe('test-project');
-           expect(graphServer.instance).toBe('test-instance');
-           expect(graphServer.database).toBe('test-database');
-           expect(graphServer.mock).toBe(false);
+           expect(graphServer.params).toStrictEqual(
+            {'project': 'test-project',
+             'instance': 'test-instance',
+             'database': 'test-database',
+             'mock': false
+           });
         });
 
         it('should fail to initialize when no port is provided', () => {
@@ -49,10 +52,7 @@ describe('GraphServer', () => {
 
             const defaultServer = new GraphServer(
                 null,
-                'test-project',
-                'test-instance',
-                'test-database',
-                false
+                {}
             );
 
             expect(console.error).toHaveBeenCalledWith('Graph Server was not given a numerical port', {port: null});
@@ -61,20 +61,17 @@ describe('GraphServer', () => {
         it('should cast a string port to a number', () => {
             const server = new GraphServer(
                 '1234',
-                'test-project',
-                'test-instance',
-                'test-database',
-                false
+                {}
             );
 
             expect(server.port).toBe(1234);
         });
 
-        it('should set project, instance, and database values', () => {
-            expect(graphServer.project).toBe('test-project');
-            expect(graphServer.instance).toBe('test-instance');
-            expect(graphServer.database).toBe('test-database');
-            expect(graphServer.mock).toBe(false);
+        it('should set params values', () => {
+            expect(graphServer.params.project).toBe('test-project');
+            expect(graphServer.params.instance).toBe('test-instance');
+            expect(graphServer.params.database).toBe('test-database');
+            expect(graphServer.params.mock).toBe(false);
         });
     });
 
@@ -119,10 +116,12 @@ describe('GraphServer', () => {
                     method: 'POST',
                     body: JSON.stringify({
                         query: queryString,
-                        project: 'test-project',
-                        instance: 'test-instance',
-                        database: 'test-database',
-                        mock: false
+                        params: {
+                            'project': 'test-project',
+                            'instance': 'test-instance',
+                            'database': 'test-database',
+                            'mock': false
+                        }
                     })
                 }
             );

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -207,16 +207,16 @@ database_instances: dict[str, SpannerDatabase | MockSpannerDatabase] = {
 }
 
 
-def get_database_instance(project: str, instance: str, database: str, mock = False):
-    if mock:
+def get_database_instance(params):
+    if params['mock']:
         return MockSpannerDatabase()
 
-    key = f"{project}_{instance}_{database}"
+    key = f"{params['project']}_{params['instance']}_{params['database']}"
 
     db = database_instances.get(key, None)
     if not db:
         # Now create and insert it.
-        db = SpannerDatabase(project, instance, database)
+        db = SpannerDatabase(params['project'], params['instance'], params['database'])
         database_instances[key] = db
 
     return db

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -108,18 +108,13 @@ class SpannerDatabase:
             self.schema_json = self._get_schema_for_graph(query)
 
         with self.database.snapshot() as snapshot:
-            log = ''
-
             params = None
             if limit and limit > 0:
                 params = dict(limit=limit)
 
             results = snapshot.execute_sql(query, params=params)
-            log += 'results:\n' + str(results) + '\n\n'
-            rows = list(results)            
+            rows = list(results)
             fields: List[StructType.Field] = results.fields
-            log += 'fields:\n' + str(fields) + '\n\n'
-            log += 'rows:\n' + str(rows) + '\n\n'
 
             data = {field.name: [] for field in fields}
 
@@ -127,20 +122,13 @@ class SpannerDatabase:
                 return data, fields, rows
 
             for row in rows:
-                log += 'row:\n' + str(row) + '\n\n'
                 for field, value in zip(fields, row):
-                    log += '  field: ' + str(field) + ', value: ' + str(value) + '\n\n'
                     if isinstance(value, JsonObject):
-                        log += '  (json path):\n' + value.serialize() + '\n\n'
                         # Handle JSON objects by properly deserializing them back into Python objects
                         data[field.name].append(json.loads(value.serialize()))
                     else:
-                        log += '  (non-json path)\n'
                         data[field.name].append(value)
 
-            #log = f'data: %s\n\nfields: %s\n\nrows: %s\n\nschema_json: %s\n' % (data, fields, rows, self.schema_json)
-            from IPython.core.getipython import get_ipython
-            get_ipython().push({'debug': log})
             return data, fields, rows, self.schema_json
 
 

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -207,7 +207,7 @@ database_instances: dict[str, SpannerDatabase | MockSpannerDatabase] = {
 }
 
 
-def get_database_instance(params):
+def get_spanner_database_instance(params):
     if params['mock']:
         return MockSpannerDatabase()
 

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -219,16 +219,16 @@ database_instances: dict[str, SpannerDatabase | MockSpannerDatabase] = {
 }
 
 
-def get_spanner_database_instance(params):
-    if params['mock']:
+def get_database_instance(project: str, instance: str, database: str, mock = False):
+    if mock:
         return MockSpannerDatabase()
 
-    key = f"{params['project']}_{params['instance']}_{params['database']}"
+    key = f"{project}_{instance}_{database}"
 
     db = database_instances.get(key, None)
     if not db:
         # Now create and insert it.
-        db = SpannerDatabase(params['project'], params['instance'], params['database'])
+        db = SpannerDatabase(project, instance, database)
         database_instances[key] = db
 
     return db

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -108,13 +108,18 @@ class SpannerDatabase:
             self.schema_json = self._get_schema_for_graph(query)
 
         with self.database.snapshot() as snapshot:
+            log = ''
+
             params = None
             if limit and limit > 0:
                 params = dict(limit=limit)
 
             results = snapshot.execute_sql(query, params=params)
-            rows = list(results)
+            log += 'results:\n' + str(results) + '\n\n'
+            rows = list(results)            
             fields: List[StructType.Field] = results.fields
+            log += 'fields:\n' + str(fields) + '\n\n'
+            log += 'rows:\n' + str(rows) + '\n\n'
 
             data = {field.name: [] for field in fields}
 
@@ -122,13 +127,20 @@ class SpannerDatabase:
                 return data, fields, rows
 
             for row in rows:
+                log += 'row:\n' + str(row) + '\n\n'
                 for field, value in zip(fields, row):
+                    log += '  field: ' + str(field) + ', value: ' + str(value) + '\n\n'
                     if isinstance(value, JsonObject):
+                        log += '  (json path):\n' + value.serialize() + '\n\n'
                         # Handle JSON objects by properly deserializing them back into Python objects
                         data[field.name].append(json.loads(value.serialize()))
                     else:
+                        log += '  (non-json path)\n'
                         data[field.name].append(value)
 
+            #log = f'data: %s\n\nfields: %s\n\nrows: %s\n\nschema_json: %s\n' % (data, fields, rows, self.schema_json)
+            from IPython.core.getipython import get_ipython
+            get_ipython().push({'debug': log})
             return data, fields, rows, self.schema_json
 
 

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -130,7 +130,7 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
     def do_json_response(self, data):
         self.send_response(200)
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header('Content-type', 'application/json')
+        self.send_header("Content-type", "application/json")
         self.send_header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS")
         self.end_headers()
         self.wfile.write(json.dumps(data).encode())
@@ -142,23 +142,21 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         self.do_json_response(data)
 
     def parse_post_data(self):
-        content_length = int(self.headers['Content-Length'])
-        post_data = self.rfile.read(content_length).decode('utf-8')
+        content_length = int(self.headers["Content-Length"])
+        post_data = self.rfile.read(content_length).decode("utf-8")
         return json.loads(post_data)
 
     def handle_get_ping(self):
-        self.do_message_response('pong')
+        self.do_message_response("pong")
 
     def handle_post_ping(self):
         data = self.parse_post_data()
-        self.do_data_response({'your_request': data})
+        self.do_data_response({"your_request": data})
 
     def handle_post_query(self):
         data = self.parse_post_data()
-        params = json.loads(data['params'])
-        response = execute_query(
-
-            
+        params = json.loads(data["params"])
+        response = execute_query(            
             project=params["project"],
             instance=params["instance"],
             database=params["database"],

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -24,41 +24,6 @@ import atexit
 from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_native_numpy
 from spanner_graphs.database import get_database_instance
 
-
-def execute_query(query: str, params):
-    database = get_database_instance(params)
-
-    try:
-        query_result, fields, rows, schema_json = database.execute_query(query)
-        d, ignored_columns = columns_to_native_numpy(query_result, fields)
-
-        graph: DiGraph = prepare_data_for_graphing(
-            incoming=d,
-            schema_json=schema_json)
-
-        nodes = []
-        for (node_id, node) in graph.nodes(data=True):
-            nodes.append(node)
-
-        edges = []
-        for (from_id, to_id, edge) in graph.edges(data=True):
-            edges.append(edge)
-
-        return {
-            "response": {
-                "nodes": nodes,
-                "edges": edges,
-                "schema": schema_json,
-                "rows": rows,
-                "query_result": query_result
-            }
-        }
-    except Exception as e:
-        return {
-            "error": getattr(e, "message", str(e))
-        }
-
-
 class GraphServer:
     port = portpicker.pick_unused_port()
     host = 'http://localhost'

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -24,6 +24,7 @@ import atexit
 from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_native_numpy
 from spanner_graphs.database import get_database_instance
 
+
 def execute_query(project: str, instance: str, database: str, query: str, mock = False):
     database = get_database_instance(project, instance, database, mock)
 
@@ -57,6 +58,7 @@ def execute_query(project: str, instance: str, database: str, query: str, mock =
             "error": getattr(e, "message", str(e))
         }
 
+
 class GraphServer:
     port = portpicker.pick_unused_port()
     host = 'http://localhost'
@@ -84,6 +86,7 @@ class GraphServer:
 
         with ThreadedTCPServer(("", GraphServer.port), GraphServerHandler) as httpd:
             GraphServer._server = httpd
+            print(f"Spanner Graph Notebook loaded")
             GraphServer._server.serve_forever()
 
     @staticmethod
@@ -154,11 +157,11 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         data = self.parse_post_data()
         params = json.loads(data['params'])
         response = execute_query(
-            query=data['query'],
-            project=params['project'],
-            instance=params['instance'],
-            database=params['database'],
-            mock=params['mock']
+            project=params["project"],
+            instance=params["instance"],
+            database=params["database"],
+            query=data["query"],
+            mock=params["mock"]
         )
         self.do_data_response(response)
 

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -22,7 +22,6 @@ from networkx.classes import DiGraph
 import atexit
 
 from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_native_numpy
-from spanner_graphs.database import get_database_instance
 from spanner_graphs.graph_visualization import execute_query
 
 class GraphServer:

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -157,6 +157,8 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         data = self.parse_post_data()
         params = json.loads(data['params'])
         response = execute_query(
+
+            
             project=params["project"],
             instance=params["instance"],
             database=params["database"],

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -25,8 +25,8 @@ from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_nati
 from spanner_graphs.database import get_database_instance
 
 
-def execute_query(project: str, instance: str, database: str, query: str, mock = False):
-    database = get_database_instance(project, instance, database, mock)
+def execute_query(query: str, params):
+    database = get_database_instance(params)
 
     try:
         query_result, fields, rows, schema_json = database.execute_query(query)
@@ -156,11 +156,8 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
     def handle_post_query(self):
         data = self.parse_post_data()
         response = execute_query(
-            project=data["project"],
-            instance=data["instance"],
-            database=data["database"],
-            query=data["query"],
-            mock=data["mock"]
+            query=data['query'],
+            params=json.loads(data['params'])
         )
         self.do_data_response(response)
 

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -51,7 +51,6 @@ class GraphServer:
 
         with ThreadedTCPServer(("", GraphServer.port), GraphServerHandler) as httpd:
             GraphServer._server = httpd
-            print(f"Spanner Graph Notebook loaded")
             GraphServer._server.serve_forever()
 
     @staticmethod

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -23,6 +23,7 @@ import atexit
 
 from spanner_graphs.conversion import prepare_data_for_graphing, columns_to_native_numpy
 from spanner_graphs.database import get_database_instance
+from spanner_graphs.graph_visualization import execute_query
 
 class GraphServer:
     port = portpicker.pick_unused_port()

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -113,7 +113,7 @@ def execute_query(query: str, params):
     # Note that the import is here, rather than at the top of the file, as the `bigquery_magics` module may
     # not exist in code paths where the 'bigquery' param is not set.
     if 'bigquery' in params:
-         from bigquery_magics import get_bigquery_database_instance
+         from bigquery_magics.bigquery import get_bigquery_database_instance
          database = get_bigquery_database_instance(params)
     else:
         database = get_spanner_database_instance(params)

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -50,35 +50,35 @@ def _load_image(path: list[str]) -> str:
         with open(file_path, 'rb') as file:
             return base64.b64decode(file.read()).decode('utf-8')
 
-def generate_visualization_html(query, url, params):
-        # Get the directory of the current file (graph_visualization.py)
+def generate_visualization_html(query, port, params):
+        # Get the directory of the current file (magics.py)
         current_dir = os.path.dirname(os.path.abspath(__file__))
 
         # Go up directories until we find the 'templates' folder
         search_dir = current_dir
-        while 'templates' not in os.listdir(search_dir):
+        while 'frontend' not in os.listdir(search_dir):
             parent = os.path.dirname(search_dir)
             if parent == search_dir:  # We've reached the root directory after I updated
-                raise FileNotFoundError("Could not find 'templates' directory")
+                raise FileNotFoundError("Could not find 'frontend' directory")
             search_dir = parent
 
         # Retrieve the javascript content
-        template_content = _load_file([search_dir, 'templates', 'template-spannergraph.html'])
-        schema_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'schema.js'])
-        graph_object_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'graph-object.js'])
-        node_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'node.js'])
-        edge_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'edge.js'])
-        config_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-config.js'])
-        store_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-store.js'])
-        menu_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-menu.js'])
-        graph_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-forcegraph.js'])
-        sidebar_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-sidebar.js'])
-        table_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-table.js'])
-        server_content = _load_file([search_dir, 'templates', 'spanner-graph', 'graph-server.js'])
-        app_content = _load_file([search_dir, 'templates', 'spanner-graph', 'app.js'])
+        template_content = _load_file([search_dir, 'frontend', 'static', 'index.html'])
+        schema_content = _load_file([search_dir, 'frontend', 'src', 'models', 'schema.js'])
+        graph_object_content = _load_file([search_dir, 'frontend', 'src', 'models', 'graph-object.js'])
+        node_content = _load_file([search_dir, 'frontend', 'src', 'models', 'node.js'])
+        edge_content = _load_file([search_dir, 'frontend', 'src', 'models', 'edge.js'])
+        config_content = _load_file([search_dir, 'frontend', 'src', 'spanner-config.js'])
+        store_content = _load_file([search_dir, 'frontend', 'src', 'spanner-store.js'])
+        menu_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-menu.js'])
+        graph_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-forcegraph.js'])
+        sidebar_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-sidebar.js'])
+        table_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-table.js'])
+        server_content = _load_file([search_dir, 'frontend', 'src', 'graph-server.js'])
+        app_content = _load_file([search_dir, 'frontend', 'src', 'app.js'])
 
         # Retrieve image content
-        graph_background_image = _load_image([search_dir, "templates", "assets", "images", "graph-bg.svg"])
+        graph_background_image = _load_image([search_dir, "frontend", "static", "graph-bg.svg"])
 
         # Create a Jinja2 template
         template = Template(template_content)
@@ -101,7 +101,7 @@ def generate_visualization_html(query, url, params):
             app_content=app_content,
             query=query,
             params=json.dumps(params),
-            url=url,
+            port=port,
             id=uuid.uuid4().hex # Prevent html/js selector collisions between cells
         )
 

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Magic class for our visualization"""
+
+import base64
+import uuid
+from enum import Enum, auto
+import json
+import os
+
+from jinja2 import Template
+
+from spanner_graphs.database import get_database_instance
+from spanner_graphs.graph_server import GraphServer, execute_query
+
+def _load_file(path: list[str]) -> str:
+        file_path = os.path.sep.join(path)
+        if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Template file not found: {file_path}")
+
+        with open(file_path, 'r') as file:
+                content = file.read()
+
+        return content
+
+def _load_image(path: list[str]) -> str:
+    file_path = os.path.sep.join(path)
+    if not os.path.exists(file_path):
+        print("image does not exist")
+        return ''
+
+    if file_path.lower().endswith('.svg'):
+        with open(file_path, 'r') as file:
+            svg = file.read()
+            return base64.b64encode(svg.encode('utf-8')).decode('utf-8')
+    else:
+        with open(file_path, 'rb') as file:
+            return base64.b64decode(file.read()).decode('utf-8')
+
+def generate_visualization_html(query, params):
+        # Get the directory of the current file (graph_visualization.py)
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Go up directories until we find the 'templates' folder
+        search_dir = current_dir
+        while 'templates' not in os.listdir(search_dir):
+            parent = os.path.dirname(search_dir)
+            if parent == search_dir:  # We've reached the root directory after I updated
+                raise FileNotFoundError("Could not find 'templates' directory")
+            search_dir = parent
+
+        # Retrieve the javascript content
+        template_content = _load_file([search_dir, 'templates', 'template-spannergraph.html'])
+        schema_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'schema.js'])
+        graph_object_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'graph-object.js'])
+        node_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'node.js'])
+        edge_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'edge.js'])
+        config_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-config.js'])
+        store_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-store.js'])
+        graph_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-forcegraph.js'])
+        sidebar_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-sidebar.js'])
+        server_content = _load_file([search_dir, 'templates', 'spanner-graph', 'graph-server.js'])
+        app_content = _load_file([search_dir, 'templates', 'spanner-graph', 'app.js'])
+
+        # Retrieve image content
+        graph_background_image = _load_image([search_dir, "templates", "assets", "images", "graph-bg.svg"])
+
+        # Create a Jinja2 template
+        template = Template(template_content)
+
+        # Render the template with the graph data and JavaScript content
+        html_content = template.render(
+            graph_background_image=graph_background_image,
+            template_content=template_content,
+            schema_content=schema_content,
+            graph_object_content=graph_object_content,
+            node_content=node_content,
+            edge_content=edge_content,
+            config_content=config_content,
+            graph_content=graph_content,
+            store_content=store_content,
+            sidebar_content=sidebar_content,
+            server_content=server_content,
+            app_content=app_content,
+            query=query,
+            params=json.dumps(params),
+            url=GraphServer.url,
+            id=uuid.uuid4().hex # Prevent html/js selector collisions between cells
+        )
+
+        return html_content

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -70,8 +70,10 @@ def generate_visualization_html(query, url, params):
         edge_content = _load_file([search_dir, 'templates', 'spanner-graph', 'models', 'edge.js'])
         config_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-config.js'])
         store_content = _load_file([search_dir, 'templates', 'spanner-graph', 'spanner-store.js'])
+        menu_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-menu.js'])
         graph_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-forcegraph.js'])
         sidebar_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-sidebar.js'])
+        table_content = _load_file([search_dir, 'templates', 'spanner-graph', 'visualization', 'spanner-table.js'])
         server_content = _load_file([search_dir, 'templates', 'spanner-graph', 'graph-server.js'])
         app_content = _load_file([search_dir, 'templates', 'spanner-graph', 'app.js'])
 
@@ -90,9 +92,11 @@ def generate_visualization_html(query, url, params):
             node_content=node_content,
             edge_content=edge_content,
             config_content=config_content,
+            menu_content=menu_content,
             graph_content=graph_content,
             store_content=store_content,
             sidebar_content=sidebar_content,
+            table_content=table_content,
             server_content=server_content,
             app_content=app_content,
             query=query,
@@ -102,6 +106,7 @@ def generate_visualization_html(query, url, params):
         )
 
         return html_content
+
 
 def execute_query(query: str, params):
     database = get_database_instance(params)

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -47,7 +47,7 @@ def _load_image(path: list[str]) -> str:
         with open(file_path, 'rb') as file:
             return base64.b64decode(file.read()).decode('utf-8')
 
-def generate_visualization_html(query, port, params):
+def generate_visualization_html(query: str, port: int, params: str):
         # Get the directory of the current file (magics.py)
         current_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -97,7 +97,7 @@ def generate_visualization_html(query, port, params):
             server_content=server_content,
             app_content=app_content,
             query=query,
-            params=json.dumps(params),
+            params=params,
             port=port,
             id=uuid.uuid4().hex # Prevent html/js selector collisions between cells
         )

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -80,13 +80,13 @@ def is_colab() -> bool:
     except ImportError:
         return False
 
-def receive_query_request(query, params):
-    params = json.loads(data['params'])
-    return JSON(execute_query(query, 
-                              project=params['project'],
-                              instance=params['instance'],
-                              database=params['database'],
-                              mock=params['mock']))
+def receive_query_request(query: str, params: str):
+    params_dict = json.loads(params)
+    return JSON(execute_query(project=params_dict["project"],
+                              instance=params_dict["instance"],
+                              database=params_dict["database"],
+                              query=query,
+                              mock=params_dict["mock"]))
 
 @magics_class
 class NetworkVisualizationMagics(Magics):
@@ -115,15 +115,15 @@ class NetworkVisualizationMagics(Magics):
             query=self.cell,
             port=GraphServer.port,
             params={
-                 'project':self.args.project,
-                 'instance':self.args.instance,
-                 'database':self.args.database,
-                 'mock':self.args.mock,
+                 "project":self.args.project,
+                 "instance":self.args.instance,
+                 "database":self.args.database,
+                 "mock":self.args.mock,
             })
         display(HTML(html_content))
 
     @cell_magic
-    def spanner_graph(self, line: str, cell: str):        
+    def spanner_graph(self, line: str, cell: str):
         """spanner_graph function"""
         parser = argparse.ArgumentParser(
             description="Visualize network from Spanner database",
@@ -154,9 +154,6 @@ class NetworkVisualizationMagics(Magics):
                 mock=self.args.mock)
             clear_output(wait=True)
             self.visualize()
-
-        except ValueError as e:
-             raise e
         except BaseException as e:
             print(f"Error: {e}")
             print("Usage: %%spanner_graph --project PROJECT_ID "

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -62,69 +62,6 @@ def _load_image(path: list[str]) -> str:
         with open(file_path, 'rb') as file:
             return base64.b64decode(file.read()).decode('utf-8')
 
-def _generate_html(query, project: str, instance: str, database: str, mock: bool):
-        # Get the directory of the current file (magics.py)
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-
-        # Go up directories until we find the 'templates' folder
-        search_dir = current_dir
-        while 'frontend' not in os.listdir(search_dir):
-            parent = os.path.dirname(search_dir)
-            if parent == search_dir:  # We've reached the root directory after I updated
-                raise FileNotFoundError("Could not find 'frontend' directory")
-            search_dir = parent
-
-        # Retrieve the javascript content
-        template_content = _load_file([search_dir, 'frontend', 'static', 'index.html'])
-        schema_content = _load_file([search_dir, 'frontend', 'src', 'models', 'schema.js'])
-        graph_object_content = _load_file([search_dir, 'frontend', 'src', 'models', 'graph-object.js'])
-        node_content = _load_file([search_dir, 'frontend', 'src', 'models', 'node.js'])
-        edge_content = _load_file([search_dir, 'frontend', 'src', 'models', 'edge.js'])
-        config_content = _load_file([search_dir, 'frontend', 'src', 'spanner-config.js'])
-        store_content = _load_file([search_dir, 'frontend', 'src', 'spanner-store.js'])
-        menu_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-menu.js'])
-        graph_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-forcegraph.js'])
-        sidebar_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-sidebar.js'])
-        table_content = _load_file([search_dir, 'frontend', 'src', 'visualization', 'spanner-table.js'])
-        server_content = _load_file([search_dir, 'frontend', 'src', 'graph-server.js'])
-        app_content = _load_file([search_dir, 'frontend', 'src', 'app.js'])
-
-        # Retrieve image content
-        graph_background_image = _load_image([search_dir, "frontend", "static", "graph-bg.svg"])
-
-        # Create a Jinja2 template
-        template = Template(template_content)
-
-        # Render the template with the graph data and JavaScript content
-        html_content = template.render(
-            graph_background_image=graph_background_image,
-            template_content=template_content,
-            schema_content=schema_content,
-            graph_object_content=graph_object_content,
-            node_content=node_content,
-            edge_content=edge_content,
-            config_content=config_content,
-            menu_content=menu_content,
-            graph_content=graph_content,
-            store_content=store_content,
-            sidebar_content=sidebar_content,
-            table_content=table_content,
-            server_content=server_content,
-            app_content=app_content,
-            query=query,
-            port=GraphServer.port,
-            params=json.dumps({
-                 'project':project,
-                 'instance':instance,
-                 'database':database,
-                 'mock':mock
-            }),
-            id=uuid.uuid4().hex # Prevent html/js selector collisions between cells
-        )
-
-        return html_content
-
-
 def _parse_element_display(element_rep: str) -> dict[str, str]:
     """Helper function to parse element display fields into a dict."""
     if not element_rep:
@@ -171,7 +108,7 @@ class NetworkVisualizationMagics(Magics):
         # Generate the HTML content
         html_content = generate_visualization_html(
             query=self.cell,
-            url=GraphServer.url,
+            port=GraphServer.port,
             params={
                  'project':self.args.project,
                  'instance':self.args.instance,

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -32,7 +32,7 @@ import ipywidgets as widgets
 from ipywidgets import interact
 from jinja2 import Template
 
-from spanner_graphs.database import get_database_instance
+from spanner_graphs.database import get_spanner_database_instance
 from spanner_graphs.graph_server import GraphServer
 from spanner_graphs.graph_visualization import execute_query, generate_visualization_html
 
@@ -205,7 +205,7 @@ class NetworkVisualizationMagics(Magics):
 
             self.args = parser.parse_args(line.split())
             self.cell = cell
-            self.database = get_database_instance(
+            self.database = get_spanner_database_instance(
                 {'project': self.args.project,
                  'instance': self.args.instance,
                  'database':self.args.database,

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -115,10 +115,10 @@ class NetworkVisualizationMagics(Magics):
             query=self.cell,
             port=GraphServer.port,
             params={
-                 "project":self.args.project,
-                 "instance":self.args.instance,
-                 "database":self.args.database,
-                 "mock":self.args.mock,
+                 "project": self.args.project,
+                 "instance": self.args.instance,
+                 "database": self.args.database,
+                 "mock": self.args.mock,
             })
         display(HTML(html_content))
 

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -114,12 +114,12 @@ class NetworkVisualizationMagics(Magics):
         html_content = generate_visualization_html(
             query=self.cell,
             port=GraphServer.port,
-            params={
+            params=json.dumps({
                  "project": self.args.project,
                  "instance": self.args.instance,
                  "database": self.args.database,
                  "mock": self.args.mock,
-            })
+            }))
         display(HTML(html_content))
 
     @cell_magic

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -32,9 +32,9 @@ import ipywidgets as widgets
 from ipywidgets import interact
 from jinja2 import Template
 
-from spanner_graphs.database import get_spanner_database_instance
-from spanner_graphs.graph_server import GraphServer
-from spanner_graphs.graph_visualization import execute_query, generate_visualization_html
+from spanner_graphs.database import get_database_instance
+from spanner_graphs.graph_server import GraphServer, execute_query
+from spanner_graphs.graph_visualization import generate_visualization_html
 
 singleton_server_thread: Thread = None
 
@@ -81,7 +81,12 @@ def is_colab() -> bool:
         return False
 
 def receive_query_request(query, params):
-    return JSON(execute_query(query, json.loads(params)))
+    params = json.loads(data['params'])
+    return JSON(execute_query(query, 
+                              project=params['project'],
+                              instance=params['instance'],
+                              database=params['database'],
+                              mock=params['mock']))
 
 @magics_class
 class NetworkVisualizationMagics(Magics):
@@ -142,12 +147,11 @@ class NetworkVisualizationMagics(Magics):
 
             self.args = parser.parse_args(line.split())
             self.cell = cell
-            self.database = get_spanner_database_instance(
-                {'project': self.args.project,
-                 'instance': self.args.instance,
-                 'database':self.args.database,
-                 'mock':self.args.mock})
-
+            self.database = get_database_instance(
+                self.args.project,
+                self.args.instance,
+                self.args.database,
+                mock=self.args.mock)
             clear_output(wait=True)
             self.visualize()
 

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -176,7 +176,7 @@ class NetworkVisualizationMagics(Magics):
                  'project':self.args.project,
                  'instance':self.args.instance,
                  'database':self.args.database,
-                 'mock':self.args.mock
+                 'mock':self.args.mock,
             })
         display(HTML(html_content))
 


### PR DESCRIPTION
Refactor spanner-graph-notebook so that non-Spanner engines can make use of the visualization code.

To use the visualization logic, an engine should:
- import this repository
- implement their own magics and python graph server class.
- call helper functions in this library to generate the html and convert the graph data.

To allow the HTML and Javascript components to be reused, instead of passing project/database/instance/mock arguments around as first-class parameters (which are all Spanner-specific), we replace these parameters with one 'params' argument, representing all the context information to be passed through to the python graph server. In the spanner context, params is a json-encoding string representing the project/database/instance/mock; in other engines, it can be substituted with something different.