### PR TITLE
UI: Typography and spacing refinements

### DIFF
--- a/templates/spanner-graph/app.js
+++ b/templates/spanner-graph/app.js
@@ -163,7 +163,7 @@ class SpannerApp {
             throw Error("Must have a valid HTML element to mount the app");
         }
 
-        this.mount.className = `${this.mount.className} container`;
+        this.mount.className = `${this.mount.className}`;
         this.mount.innerHTML = `
             <style>
                 .container {
@@ -174,10 +174,11 @@ class SpannerApp {
             
                     margin: 0;
                     padding: 0;
-                    font-family: 'Google Sans', Roboto, Arial, sans-serif;
                     overflow: hidden;
+                    width: calc(100% - .5rem);
                                      
                     background-color: #fff;
+                    font: 16px 'Google Sans', Roboto, Arial, sans-serif;
                 }
             
                 .container .content {

--- a/templates/spanner-graph/visualization/spanner-forcegraph.js
+++ b/templates/spanner-graph/visualization/spanner-forcegraph.js
@@ -391,6 +391,11 @@ class GraphVisualization {
         }
     }
 
+    _getRecenterPadding() {
+        return this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA ?
+            64 : 16;
+    }
+
     _setupGraphTools(graphObject) {
         const html = `
             <button id="graph-zoom-in" title="Zoom In" fill="#3C4043">
@@ -421,7 +426,7 @@ class GraphVisualization {
 
         this.tools.elements.recenter = this.tools.elements.container.querySelector('#graph-recenter');
         this.tools.elements.recenter.addEventListener('click', () => {
-            graphObject.zoomToFit(this.tools.config.recenterSpeed);
+            graphObject.zoomToFit(this.tools.config.recenterSpeed, this._getRecenterPadding());
         });
 
         this.tools.elements.zoomIn = this.tools.elements.container.querySelector('#graph-zoom-in');
@@ -1210,7 +1215,7 @@ class GraphVisualization {
         // fit to canvas when engine stops
         this.graph.onEngineStop(() => {
             if (this.requestedRecenter) {
-                this.graph.zoomToFit(1000, 16);
+                this.graph.zoomToFit(1000, this._getRecenterPadding());
                 this.requestedRecenter = false;
             }
         });

--- a/templates/spanner-graph/visualization/spanner-menu.js
+++ b/templates/spanner-graph/visualization/spanner-menu.js
@@ -162,6 +162,7 @@ class SpannerMenu {
                     margin-left: 8px;
                     color: #202124;
                     line-height: 24px;
+                    font-size: .9rem;
                 }
                 .graph-element-tooltip {
                     font: 12px 'Google Sans', 'Roboto', sans-serif;
@@ -196,9 +197,12 @@ class SpannerMenu {
                     border-radius: 4px;
                     color: #3C4043;
                     cursor: pointer;
-                    font-size: 16px;
                     text-align: left;
-                    width: 260px;
+                    
+                    width: 220px;
+
+                    font-family: inherit;
+                    font-size: .9rem;
                 }
                 
                 .dropdown-toggle.disabled {
@@ -260,6 +264,7 @@ class SpannerMenu {
 
                 .item-text {
                     flex: 1;
+                    font-size: .9rem;
                 }
                 
                 #graph-tools {
@@ -351,19 +356,19 @@ class SpannerMenu {
                         </a>
                         <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.TOP_DOWN.description}">
                             <span class="checkmark"></span>
-                            <span class="item-text">Hierarchical: Top down</span>
+                            <span class="item-text">Top-down</span>
                         </a>
                         <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.LEFT_RIGHT.description}">
                             <span class="checkmark"></span>
-                            <span class="item-text">Hierarchical: Left-to-right</span>
+                            <span class="item-text">Left-to-right</span>
                         </a>
                         <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.RADIAL_IN.description}">
                             <span class="checkmark"></span>
-                            <span class="item-text">Radial: Inward</span>
+                            <span class="item-text">Radial inward</span>
                         </a>
                         <a href="#" class="dropdown-item" data-layout="${GraphConfig.LayoutModes.RADIAL_OUT.description}">
                             <span class="checkmark"></span>
-                            <span class="item-text">Radial: Outward</span>
+                            <span class="item-text">Radial outward</span>
                         </a>
                     </div>
                 </div>

--- a/templates/spanner-graph/visualization/spanner-table.js
+++ b/templates/spanner-graph/visualization/spanner-table.js
@@ -180,7 +180,7 @@ class SpannerTable {
             
                 #${this.mount.id} table.spanner-table {
                     table-layout: fixed !important;
-                    border-collapse: separate;
+                    border-collapse: collapse;
                     font-family: 'Google Sans', Roboto, Arial, sans-serif;
                     width: max-content;
                     min-width: 100%;
@@ -297,6 +297,7 @@ class SpannerTable {
                     text-overflow: ellipsis;
                     text-align: left;
                     line-height: 1.2rem;
+                    font-size: .8rem;
                 }
             
                 .expanded .cell-content {


### PR DESCRIPTION
This PR implements design feedback to improve typography hierarchy and layout spacing across the Spanner Graph UI.

Thank you Doug Hungarter for the notes and providing the needed CSS amendments!

Key changes:
- Establishes base 16px font size with consistent scaling
- Fixes double border issue in graph container
- Adds proper spacing from table cell bounds
- Improves table rendering with collapsed borders
- Refines dropdown and label typography
- Simplifies layout mode labels for better readability
- Adjusts schema view padding to 64px for better fit