### PR TITLE
Remove unnecessary error logging for non-graph queries in SpannerDatabase

### DIFF
--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -63,7 +63,6 @@ class SpannerDatabase:
         try:
             graph_name = self._extract_graph_name(graph_query)
         except ValueError as e:
-            print(f"Error extracting graph name: {str(e)}")
             return None
 
         with self.database.snapshot() as snapshot:
@@ -81,7 +80,6 @@ class SpannerDatabase:
             if schema_rows:
                 return schema_rows[0][1]
             else:
-                print(f"No schema found for graph: {graph_name}")
                 return None
 
     def execute_query(


### PR DESCRIPTION
When users execute valid non-graph queries (like SELECT statements), the previous implementation would print error messages despite the presence of an actual error. This created unnecessary noise in the output.

## Changes
- Removed unnecessary error logging in SpannerDatabase when handling queries that don't contain the word "graph"
- Removed print statement for schema not found cases