### PR TITLE
fix: Support Vertex AI Workbench

### DIFF
--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -115,7 +115,7 @@ def _generate_html(query, project: str, instance: str, database: str, mock: bool
             instance=instance,
             database=database,
             mock=mock,
-            url=GraphServer.url,
+            port=GraphServer.port,
             id=uuid.uuid4().hex # Prevent html/js selector collisions between cells
         )
 

--- a/templates/spanner-graph/app.js
+++ b/templates/spanner-graph/app.js
@@ -71,7 +71,7 @@ class SpannerApp {
         table: null
     };
 
-    constructor({id, url, project, instance, database, mock, mount, query}) {
+    constructor({id, port, project, instance, database, mock, mount, query}) {
         this.id = id;
         this.lastQuery = query;
 
@@ -83,9 +83,16 @@ class SpannerApp {
 
         this.scaffold();
 
-        this.server = new GraphServer(url, project, instance, database, mock);
+        this.server = new GraphServer(port, project, instance, database, mock);
         this.server.query(query)
-            .then(({error, response}) => {
+            .then(data => {
+                if (!data) {
+                    this.tearDown();
+                    return;
+                }
+
+                const {error, response} = data;
+
                 this.loaderElement.classList.add('hidden');
 
                 if (error || !response) {
@@ -156,6 +163,10 @@ class SpannerApp {
                     this.store.setViewMode(GraphConfig.ViewModes.TABLE);
                 }
             });
+    }
+
+    tearDown() {
+        this.mount.innerHTML = '';
     }
 
     scaffold() {

--- a/templates/spanner-graph/graph-server.js
+++ b/templates/spanner-graph/graph-server.js
@@ -25,20 +25,35 @@ class GraphServer {
     };
 
     buildRoute(endpoint) {
-        return `${this.url}${endpoint}`;
-    }
-    
-    constructor(url, project, instance, database, mock) {
-        if (url) {
-            this.url = url;
+        const hostname = window.location.hostname;
+
+        if (hostname === 'localhost' || hostname === '127.0.0.1') {
+            // Local Jupyter Notebook environment
+            return `http://localhost:${this.port}${endpoint}`;
+        } else {
+            // Assume Vertex AI Workbench JupyterLab environment (or other JupyterLab proxy setup)
+            return `/proxy/${this.port}${endpoint}`;
         }
+    }
+
+    constructor(port, project, instance, database, mock) {
+        if (typeof port !== 'number') {
+            try {
+                port = Number(port);
+            } catch (e) {
+                console.error('Graph Server was not given a numerical port', {port});
+                return;
+            }
+        }
+
+        this.port = port;
 
         this.project = project;
         this.instance = instance;
         this.database = database;
         this.mock = mock;
     }
-    
+
     query(queryString) {
         const request = {
             query: queryString,

--- a/templates/template-spannergraph.html
+++ b/templates/template-spannergraph.html
@@ -74,7 +74,7 @@ limitations under the License.
                 {
                     id: `{{ id }}`,
                     mount: document.querySelector('div.mount-{{ id }}'),
-                    url: `{{ url }}`,
+                    port: `{{ port }}`,
                     project: `{{ project }}`,
                     instance: `{{ instance }}`,
                     database: `{{ database }}`,


### PR DESCRIPTION
## Problem
The application was not functioning correctly in Vertex AI Workbench due to incorrect handling of server URLs. In Vertex AI Workbench's JupyterLab environment, server requests need to go through a proxy path (`/proxy/{port}`) rather than direct URL access.

I also took this moment to address an issue where the user sees an infinite loading spinner when loading a notebook page that has a saved graph cell output but has not yet done `%load_ext spanner_graphs`. In Jupyter Notebook, the new behavior is for nothing to appear. There is no change in behavior for Colab because "This code cell must be re-executed to allow runtime access." (as seen from console).

## Solution
This PR modifies the server connection logic to:
1. Use port numbers instead of full URLs for server configuration
2. Detect the runtime environment (localhost vs Vertex AI Workbench)
3. Construct appropriate server paths based on the environment:
   - For localhost: `http://localhost:{port}/endpoint`
   - For Vertex AI Workbench: `/proxy/{port}/endpoint`

## Changes
- `spanner_graphs/magics.py`: Replace URL parameter with port in template context
- `templates/spanner-graph/app.js`: Update constructor to use port instead of URL
- `templates/spanner-graph/graph-server.js`: 
  - Add environment detection logic
  - Add port number validation
- `templates/template-spannergraph.html`: Update template to use port parameter