### PR TITLE
docs: clarify --mock flag usage and test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ LIMIT 50
 (Note: `my-gcp-project`, `my-spanner-instance`, `my-database`, and `MyGraph` are placeholders.  Replace them with your actual values.)
 ```
 
-You can also visualize a local dataset with `--mock` flag.
+You can also visualize a local dataset with `--mock` flag. Note that since this is a cell magic command, you must include two newlines after the command:
 
 ```
 %%spanner_graph --mock
+
+
 ```
 
 
@@ -159,9 +161,12 @@ RETURN SAFE_TO_JSON(person) AS person_json,
 
 ## Testing changes
 
-After adding new changes, please run unit and integration tests with the command below:
+First, install the test dependencies:
+```shell
+pip install -r requirements-test.txt
+```
 
-
+Then run unit and integration tests with the command below:
 ```shell
 cd spanner_graphs && python -m unittest discover -s tests -p "*_test.py"
 ```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+ipython>=8.0.0
+pytest>=7.0.0
+pytest-mock>=3.10.0 

--- a/sample.ipynb
+++ b/sample.ipynb
@@ -47,7 +47,9 @@
    "source": [
     "## Query and visualize a local dataset with `--mock` flag\n",
     "\n",
-    "Visualize local datasets without connecting to a Spanner database."
+    "Visualize local datasets without connecting to a Spanner database.\n",
+    "\n",
+    "Note: Since `%%spanner_graph` is a cell magic command, you must include two newlines after the command, even when using `--mock`."
    ]
   },
   {
@@ -57,7 +59,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%spanner_graph --mock"
+    "%%spanner_graph --mock\n",
+    "\n"
    ]
   },
   {
@@ -110,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/tests/magics_test.py
+++ b/tests/magics_test.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from IPython.core.interactiveshell import InteractiveShell
+from spanner_graphs.magics import NetworkVisualizationMagics, load_ipython_extension
+
+class TestNetworkVisualizationMagics(unittest.TestCase):
+    def setUp(self):
+        # Create a proper IPython shell instance for testing
+        self.ip = InteractiveShell()
+        
+        # Initialize our magic class
+        self.magics = NetworkVisualizationMagics(self.ip)
+        
+    def test_magic_registration(self):
+        """Test that the magic gets properly registered with IPython"""
+        # Mock the IPython shell's register_magics method
+        self.ip.register_magics = MagicMock()
+        
+        # Call the extension loader
+        load_ipython_extension(self.ip)
+        
+        # Verify the magic was registered
+        self.ip.register_magics.assert_called_once_with(NetworkVisualizationMagics)
+
+    @patch('spanner_graphs.magics.get_database_instance')
+    @patch('spanner_graphs.magics.GraphServer')
+    @patch('spanner_graphs.magics.display')
+    def test_spanner_graph_magic_with_valid_args(self, mock_display, mock_server, mock_db):
+        """Test the %%spanner_graph magic with valid arguments"""
+        # Setup mock database
+        mock_db.return_value = MagicMock()
+        
+        # Setup mock server
+        mock_server.port = 8080
+        
+        # Test line with valid arguments
+        line = "--project test_project --instance test_instance --database test_db"
+        cell = "SELECT * FROM test_table"
+        
+        # Execute the magic
+        result = self.magics.spanner_graph(line, cell)
+        
+        # Verify database was initialized with correct parameters
+        mock_db.assert_called_once_with(
+            "test_project",
+            "test_instance",
+            "test_db",
+            mock=False
+        )
+        
+        # Verify display was called (exact HTML content verification would be complex)
+        mock_display.assert_called_once()
+
+    def test_spanner_graph_magic_with_invalid_args(self):
+        """Test the %%spanner_graph magic with invalid arguments"""
+        # Test with missing required arguments
+        line = "--project test_project"  # Missing instance and database
+        cell = "SELECT * FROM test_table"
+        
+        # Execute the magic and capture output
+        with patch('builtins.print') as mock_print:
+            self.magics.spanner_graph(line, cell)
+            
+            # Verify error message was printed
+            mock_print.assert_any_call(
+                "Error: Please provide `--project`, `--instance`, "
+                "and `--database` values for your query."
+            )
+
+    def test_spanner_graph_magic_with_empty_cell(self):
+        """Test the %%spanner_graph magic with empty cell content"""
+        line = "--project test_project --instance test_instance --database test_db"
+        cell = ""  # Empty cell content
+        
+        # Execute the magic and capture output
+        with patch('builtins.print') as mock_print:
+            self.magics.spanner_graph(line, cell)
+            
+            # Verify error message was printed
+            mock_print.assert_any_call(
+                "Error: Query is required."
+            )
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/tests/sample_notebook_test.py
+++ b/tests/sample_notebook_test.py
@@ -1,0 +1,114 @@
+import unittest
+import json
+from unittest.mock import MagicMock, patch
+from IPython.core.interactiveshell import InteractiveShell
+from spanner_graphs.magics import NetworkVisualizationMagics, load_ipython_extension
+
+class TestSampleNotebook(unittest.TestCase):
+    def setUp(self):
+        # Create a proper IPython shell instance for testing
+        self.ip = InteractiveShell()
+        
+        # Initialize our magic class
+        self.magics = NetworkVisualizationMagics(self.ip)
+        
+        # Load the notebook content
+        with open('sample.ipynb', 'r') as f:
+            self.notebook = json.load(f)
+            
+        # Extract all code cells
+        self.code_cells = [cell for cell in self.notebook['cells'] 
+                          if cell['cell_type'] == 'code']
+
+    def test_notebook_cells(self):
+        """Test all code cells from sample.ipynb"""
+        # First cell should be pip install (optional)
+        self.assertEqual(
+            self.code_cells[0]['source'],
+            ['!pip install spanner-graph-notebook']
+        )
+        
+        # Second cell should be loading the extension
+        self.assertEqual(
+            self.code_cells[1]['source'],
+            ['%load_ext spanner_graphs']
+        )
+        
+        # Test loading the extension
+        with patch.object(self.ip, 'register_magics') as mock_register:
+            self.ip.run_line_magic('load_ext', 'spanner_graphs')
+            mock_register.assert_called_with(NetworkVisualizationMagics)
+        
+        # Third cell should be mock visualization
+        mock_cell = self.code_cells[2]
+        self.assertEqual(
+            mock_cell['source'],
+            ['%%spanner_graph --mock']
+        )
+        
+        # Test the mock visualization with mocked dependencies
+        with patch('spanner_graphs.magics.get_database_instance') as mock_db, \
+             patch('spanner_graphs.magics.GraphServer') as mock_server, \
+             patch('spanner_graphs.magics.display') as mock_display:
+            
+            mock_db.return_value = MagicMock()
+            mock_server.port = 8080
+            
+            # Test with a valid query since empty cell is handled by IPython
+            line = '--mock'
+            cell = 'GRAPH FinGraph\nMATCH p = (a)-[e]->(b)\nRETURN TO_JSON(p) AS path\nLIMIT 100'
+            
+            # Execute the magic with a valid query
+            result = self.magics.spanner_graph(line, cell)
+            
+            # Verify database was initialized with mock=True
+            mock_db.assert_called_once_with(
+                None,  # project
+                None,  # instance
+                None,  # database
+                mock=True
+            )
+            
+            # Verify display was called
+            mock_display.assert_called_once()
+        
+        # Fourth cell should be the Spanner Graph query
+        query_cell = self.code_cells[3]
+        expected_source = [
+            '%%spanner_graph --project {project_id} --instance {instance_name} --database {database_name}\n',
+            '\n',
+            'GRAPH FinGraph\n',
+            'MATCH p = (a)-[e]->(b)\n',
+            'RETURN TO_JSON(p) AS path\n',
+            'LIMIT 100'
+        ]
+        self.assertEqual(query_cell['source'], expected_source)
+        
+        # Test the query with mocked dependencies
+        with patch('spanner_graphs.magics.get_database_instance') as mock_db, \
+             patch('spanner_graphs.magics.GraphServer') as mock_server, \
+             patch('spanner_graphs.magics.display') as mock_display:
+            
+            mock_db.return_value = MagicMock()
+            mock_server.port = 8080
+            
+            # Extract the actual line and cell content from the notebook
+            line = next(line for line in query_cell['source'] if line.startswith('%%spanner_graph')).replace('%%spanner_graph ', '')
+            cell = ''.join(line for line in query_cell['source'] if not line.startswith('%%spanner_graph'))
+            
+            # Execute the magic with the actual notebook content
+            result = self.magics.spanner_graph(line, cell)
+            
+            # Verify database was initialized with placeholder values
+            mock_db.assert_called_once_with(
+                "{project_id}",
+                "{instance_name}",
+                "{database_name}",
+                mock=False
+            )
+            
+            # Verify display was called
+            mock_display.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR improves documentation and testing around the `--mock` flag functionality:

- Clarifies that `%%spanner_graph --mock` requires two newlines after the command
- Adds two new test files:
  - `magics_test.py` for testing magic command functionality
  - `sample_notebook_test.py` for validating sample notebook content
- Documents test dependency requirements in `requirements-test.txt` needed to run these tests

The changes help prevent confusion for users trying to use the mock functionality and ensure proper test coverage with the necessary dependencies.