### PR TITLE
feat(dev): add development server for live database testing

### DIFF
--- a/frontend/static/dev.html
+++ b/frontend/static/dev.html
@@ -493,6 +493,14 @@ LIMIT 50"></textarea>
             const query = document.getElementById('query').value;
             const mock = document.getElementById('mock').checked;
 
+            // Save configuration to localStorage
+            localStorage.setItem('spanner-graph-config', JSON.stringify({
+                project,
+                instance,
+                database,
+                query
+            }));
+
             // Clear previous instance if it exists
             if (window.app) {
                 window.app.tearDown();
@@ -512,6 +520,20 @@ LIMIT 50"></textarea>
                 mount: mount,
                 query: query
             });
+        }
+
+        // Load saved configuration from localStorage
+        function loadSavedConfig() {
+            const savedConfig = localStorage.getItem('spanner-graph-config');
+            if (savedConfig) {
+                const config = JSON.parse(savedConfig);
+                document.getElementById('project').value = config.project || 'my-project';
+                document.getElementById('instance').value = config.instance || 'my-instance';
+                document.getElementById('database').value = config.database || 'my-database';
+                document.getElementById('query').value = config.query || '';
+            }
+            // Always ensure mock is checked on initial load
+            document.getElementById('mock').checked = true;
         }
 
         function toggleCommandPalette() {
@@ -550,6 +572,7 @@ LIMIT 50"></textarea>
             if (window && typeof window.onCustomEvent === 'function') {
                 window.onCustomEvent('page ready');
             }
+            loadSavedConfig();
             initializeApp();
         });
     </script>

--- a/frontend/static/dev.html
+++ b/frontend/static/dev.html
@@ -1,0 +1,557 @@
+<!--
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Spanner Graph Visualization Dev</title>
+    <style>
+        :root {
+            --primary-color: #1a73e8;
+            --hover-color: #1557b0;
+            --border-color: #e0e0e0;
+            --text-color: #3c4043;
+            --background-color: #f8f9fa;
+            --form-background: #ffffff;
+            --shadow-color: rgba(60, 64, 67, 0.1);
+            --overlay-color: rgba(0, 0, 0, 0.5);
+            --transition-speed: 0.2s;
+        }
+
+        html {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Google Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background-color: var(--background-color);
+            color: var(--text-color);
+            height: 100%;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .visualization-container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            background-color: var(--background-color);
+            min-height: 0; /* Critical for Firefox */
+        }
+
+        .mount-spanner-test {
+            width: 100%;
+            height: 100%;
+            flex: 1;
+            display: flex;
+            min-height: 0; /* Critical for Firefox */
+        }
+
+        .mount-spanner-test > div {
+            width: 100% !important;
+            height: 100% !important;
+            min-height: 0; /* Critical for Firefox */
+        }
+
+        /* Force override for the specific graph container */
+        #force-graph-spanner-test {
+            width: 100% !important;
+            height: 100% !important;
+            position: relative !important;
+        }
+
+        .mount-spanner-test canvas {
+            height: 100% !important;
+        }
+
+        .floating-controls {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 12px;
+            padding: 12px;
+            background: var(--form-background);
+            border-radius: 100px;
+            box-shadow: 0 4px 12px var(--shadow-color);
+            z-index: 1000;
+            transition: all var(--transition-speed) ease;
+        }
+
+        .floating-controls:hover {
+            box-shadow: 0 8px 16px var(--shadow-color);
+        }
+
+        .control-button {
+            padding: 8px 16px;
+            background: transparent;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+            border-radius: 100px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all var(--transition-speed) ease;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .control-button:hover {
+            background: var(--background-color);
+            border-color: var(--primary-color);
+        }
+
+        .control-button.active {
+            background: var(--primary-color);
+            color: white;
+            border-color: var(--primary-color);
+        }
+
+        .command-palette {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%) scale(0.95);
+            width: 600px;
+            max-height: 90vh;
+            background: var(--form-background);
+            border-radius: 12px;
+            box-shadow: 0 12px 24px var(--shadow-color);
+            opacity: 0;
+            pointer-events: none;
+            transition: all var(--transition-speed) cubic-bezier(0.4, 0, 0.2, 1);
+            z-index: 1001;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .command-palette.active {
+            transform: translate(-50%, -50%) scale(1);
+            opacity: 1;
+            pointer-events: all;
+        }
+
+        .command-input {
+            width: 100%;
+            padding: 16px;
+            border: none;
+            border-bottom: 1px solid var(--border-color);
+            border-radius: 12px 12px 0 0;
+            font-size: 16px;
+            background: transparent;
+            box-sizing: border-box;
+        }
+
+        .command-input:focus {
+            outline: none;
+            border-color: var(--primary-color);
+        }
+
+        .command-content {
+            padding: 24px;
+            overflow-y: auto;
+            flex: 1;
+            min-height: 0;
+        }
+
+        .command-section {
+            margin-bottom: 24px;
+        }
+
+        .command-section-title {
+            font-size: 12px;
+            text-transform: uppercase;
+            color: #5f6368;
+            margin-bottom: 8px;
+            letter-spacing: 0.5px;
+        }
+
+        .connection-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .connection-field {
+            position: relative;
+        }
+
+        .connection-field input {
+            width: 100%;
+            padding: 8px 12px;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            font-size: 14px;
+            background: transparent;
+            box-sizing: border-box;
+        }
+
+        .connection-field input:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.1);
+        }
+
+        .connection-field label {
+            position: absolute;
+            left: 8px;
+            top: 0;
+            transform: translateY(-50%);
+            background: var(--form-background);
+            padding: 0 4px;
+            font-size: 12px;
+            color: #5f6368;
+        }
+
+        .query-editor {
+            position: relative;
+            margin-top: 24px;
+        }
+
+        .query-editor textarea {
+            width: 100%;
+            height: 150px;
+            padding: 12px;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            font-family: 'Roboto Mono', monospace;
+            font-size: 14px;
+            line-height: 1.5;
+            resize: vertical;
+            background: transparent;
+            box-sizing: border-box;
+        }
+
+        .query-editor textarea:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.1);
+        }
+
+        .action-buttons {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+            margin-top: 16px;
+        }
+
+        .action-button {
+            padding: 8px 16px;
+            border: none;
+            border-radius: 4px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all var(--transition-speed) ease;
+        }
+
+        .action-button.secondary {
+            background: transparent;
+            color: var(--text-color);
+            border: 1px solid var(--border-color);
+        }
+
+        .action-button.primary {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .action-button:hover {
+            box-shadow: 0 1px 3px var(--shadow-color);
+        }
+
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            background: var(--overlay-color);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity var(--transition-speed) ease;
+            z-index: 1000;
+        }
+
+        .overlay.active {
+            opacity: 1;
+            pointer-events: all;
+        }
+
+        .keyboard-hint {
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            transform: translateY(-50%);
+            color: #5f6368;
+            font-size: 12px;
+            pointer-events: none;
+        }
+
+        @media (max-width: 768px) {
+            .command-palette {
+                width: 90%;
+            }
+        }
+
+        .dots {
+            background-image: url('./graph-bg.svg');
+            background-repeat: repeat;
+        }
+
+        .mock-toggle {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-top: 8px;
+            padding: 8px 0;
+        }
+
+        .mock-toggle input[type="checkbox"] {
+            appearance: none;
+            width: 36px;
+            height: 20px;
+            border-radius: 10px;
+            background: var(--border-color);
+            position: relative;
+            cursor: pointer;
+            transition: all var(--transition-speed) ease;
+        }
+
+        .mock-toggle input[type="checkbox"]::after {
+            content: '';
+            position: absolute;
+            left: 2px;
+            top: 2px;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: white;
+            transition: all var(--transition-speed) ease;
+        }
+
+        .mock-toggle input[type="checkbox"]:checked {
+            background: var(--primary-color);
+        }
+
+        .mock-toggle input[type="checkbox"]:checked::after {
+            transform: translateX(16px);
+        }
+
+        .mock-toggle label {
+            font-size: 14px;
+            color: var(--text-color);
+            user-select: none;
+        }
+
+        .command-header {
+            padding: 20px 24px;
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .command-header h2 {
+            margin: 0;
+            font-size: 18px;
+            font-weight: 500;
+            color: var(--text-color);
+        }
+
+        .keyboard-hint {
+            color: #5f6368;
+            font-size: 12px;
+            pointer-events: none;
+        }
+    </style>
+    <script src="../src/models/schema.js"></script>
+    <script src="../src/models/graph-object.js"></script>
+    <script src="../src/models/node.js"></script>
+    <script src="../src/models/edge.js"></script>
+    <script src="../src/spanner-config.js"></script>
+    <script src="../src/visualization/spanner-menu.js"></script>
+    <script src="../src/visualization/spanner-forcegraph.js"></script>
+    <script src="../src/spanner-store.js"></script>
+    <script src="../src/visualization/spanner-sidebar.js"></script>
+    <script src="../src/visualization/spanner-table.js"></script>
+    <script src="../src/graph-server.js"></script>
+    <script src="../src/app.js"></script>
+</head>
+<body>
+    <div class="visualization-container">
+        <div class="mount-spanner-test"></div>
+        
+        <div class="floating-controls">
+            <button class="control-button" onclick="toggleCommandPalette()" title="Configure (Cmd/Ctrl + K)">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M12 15V3m0 12l-4-4m4 4l4-4M2 17l.621 2.485A2 2 0 004.561 21h14.878a2 2 0 001.94-1.515L22 17"></path>
+                </svg>
+                Configure
+            </button>
+        </div>
+    </div>
+
+    <div class="overlay" id="overlay"></div>
+
+    <div class="command-palette" id="commandPalette">
+        <div class="command-header">
+            <h2>Configure Visualization</h2>
+            <span class="keyboard-hint">ESC to close</span>
+        </div>
+        
+        <div class="command-content">
+            <form id="configForm" onsubmit="handleSubmit(event)">
+                <div class="command-section">
+                    <!-- <div class="command-section-title">Connection Settings</div> -->
+                    <div class="connection-grid">
+                        <div class="connection-field">
+                            <label for="project">Project ID</label>
+                            <input type="text" id="project" value="my-project" placeholder="Enter project ID">
+                        </div>
+                        <div class="connection-field">
+                            <label for="instance">Instance ID</label>
+                            <input type="text" id="instance" value="my-instance" placeholder="Enter instance ID">
+                        </div>
+                        <div class="connection-field">
+                            <label for="database">Database</label>
+                            <input type="text" id="database" value="my-database" placeholder="Enter database name">
+                        </div>
+                    </div>
+                    <div class="mock-toggle">
+                        <input type="checkbox" id="mock" checked>
+                        <label for="mock">Use mock data</label>
+                    </div>
+                </div>
+
+                <div class="command-section">
+                    <div class="command-section-title">Query</div>
+                    <div class="query-editor">
+                        <textarea id="query" placeholder="GRAPH MyGraph
+MATCH p = (a)-[e]->(b)
+RETURN TO_JSON(p) AS path_json
+LIMIT 50"></textarea>
+                    </div>
+                </div>
+
+                <div class="action-buttons">
+                    <button type="button" class="action-button secondary" onclick="toggleCommandPalette()">Cancel</button>
+                    <button type="submit" class="action-button primary">Visualize Graph</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script>
+        let initialized = false;
+        const INJECTED_PORT = '{{PORT}}';
+
+        function loadScript(url) {
+            return new Promise((resolve, reject) => {
+                if (document.querySelector(`script[src='${url}']`)) {
+                    return resolve();
+                }
+
+                const script = document.createElement('script');
+                script.className = 'spannerviz-external-dependency'
+                script.src = url;
+                script.onload = resolve;
+                script.onerror = reject;
+                document.head.appendChild(script);
+            });
+        }
+
+        function initializeApp() {
+            const mount = document.querySelector('.mount-spanner-test');
+            const project = document.getElementById('project').value;
+            const instance = document.getElementById('instance').value;
+            const database = document.getElementById('database').value;
+            const query = document.getElementById('query').value;
+            const mock = document.getElementById('mock').checked;
+
+            // Clear previous instance if it exists
+            if (window.app) {
+                window.app.tearDown();
+            }
+
+            const params = {
+                'project': project,
+                'instance': instance,
+                'database': database,
+                'mock': mock
+            };
+
+            window.app = new SpannerApp({
+                id: 'spanner-test',
+                port: INJECTED_PORT,
+                params: JSON.stringify(params),
+                mount: mount,
+                query: query
+            });
+        }
+
+        function toggleCommandPalette() {
+            const palette = document.getElementById('commandPalette');
+            const overlay = document.getElementById('overlay');
+            palette.classList.toggle('active');
+            overlay.classList.toggle('active');
+            
+            if (palette.classList.contains('active')) {
+                palette.querySelector('input').focus();
+            }
+        }
+
+        function handleSubmit(e) {
+            e.preventDefault();
+            toggleCommandPalette();
+            initializeApp();
+        }
+
+        // Keyboard shortcuts
+        document.addEventListener('keydown', (e) => {
+            if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                toggleCommandPalette();
+            } else if (e.key === 'Escape' && document.getElementById('commandPalette').classList.contains('active')) {
+                toggleCommandPalette();
+            }
+        });
+
+        Promise.all([
+            loadScript('https://d3js.org/d3.v5.min.js'),
+            loadScript('https://unpkg.com/d3-dsv'),
+            loadScript('https://unpkg.com/d3-force'),
+            loadScript('https://unpkg.com/force-graph')
+        ]).then(() => {
+            if (window && typeof window.onCustomEvent === 'function') {
+                window.onCustomEvent('page ready');
+            }
+            initializeApp();
+        });
+    </script>
+</body>
+</html> 

--- a/spanner_graphs/dev_util/README.md
+++ b/spanner_graphs/dev_util/README.md
@@ -1,0 +1,21 @@
+# Development Setup
+
+For local development and testing of the visualization, you can use the development server:
+
+```shell
+cd spanner_graphs/dev_util
+python serve_dev.py
+```
+
+This will:
+1. Start a Python backend server that handles Spanner Graph queries
+2. Start a frontend server serving the development interface
+3. Open your browser to the development interface at http://localhost:8000/static/dev.html
+
+The development interface provides a form where you can:
+- Configure your GCP project, instance, and database
+- Toggle between mock and real data
+- Write and execute Spanner Graph queries
+- Visualize the results in real-time
+
+Note: The development server is separate from the test server (`npm run test:serve-content`) which is used specifically for running the frontend test suite.

--- a/spanner_graphs/dev_util/serve_dev.py
+++ b/spanner_graphs/dev_util/serve_dev.py
@@ -1,0 +1,115 @@
+# Copyright 2025 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import threading
+import http.server
+import socketserver
+from pathlib import Path
+
+# Add the project root to Python path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from spanner_graphs.graph_server import GraphServer
+
+class FrontendServer:
+    def __init__(self, port=8000):
+        self.port = port
+        self.server = None
+        
+    def start(self):
+        # Change to the frontend directory
+        os.chdir(str(project_root / 'frontend'))
+        
+        # Create handler that allows CORS and injects the GraphServer port
+        class DevServerHandler(http.server.SimpleHTTPRequestHandler):
+            def end_headers(self):
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+                self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+                super().end_headers()
+                
+            def do_OPTIONS(self):
+                self.send_response(200)
+                self.end_headers()
+
+            def do_GET(self):
+                if self.path == "/" or self.path == "/index.html":
+                    # Redirect to dev.html
+                    self.send_response(302)
+                    self.send_header('Location', '/static/dev.html')
+                    self.end_headers()
+                    return
+                
+                # Special handling for dev.html to inject the port
+                if self.path == "/static/dev.html":
+                    try:
+                        with open(os.path.join(os.getcwd(), "static/dev.html"), 'r') as f:
+                            content = f.read()
+                            # Inject the GraphServer port
+                            content = content.replace("{{PORT}}", str(GraphServer.port))
+                            
+                            self.send_response(200)
+                            self.send_header('Content-type', 'text/html')
+                            self.end_headers()
+                            self.wfile.write(content.encode())
+                            return
+                    except Exception as e:
+                        print(f"Error serving dev.html: {e}")
+                        self.send_error(500, "Internal Server Error")
+                        return
+                
+                # Default handling for all other files
+                super().do_GET()
+        
+        # Start the server
+        class ThreadedTCPServer(socketserver.TCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+            
+        self.server = ThreadedTCPServer(("", self.port), DevServerHandler)
+        print(f"\nFrontend server started at http://localhost:{self.port}")
+        print(f"Visit http://localhost:{self.port}/static/dev.html to access the development interface")
+        self.server.serve_forever()
+    
+    def stop(self):
+        if self.server:
+            self.server.shutdown()
+            self.server.server_close()
+
+def main():
+    try:
+        # Start the graph server first (it creates its own thread internally)
+        graph_server_thread = GraphServer.init()
+        
+        # Start the frontend server in a separate thread
+        frontend_server = FrontendServer()
+        frontend_thread = threading.Thread(target=frontend_server.start)
+        frontend_thread.daemon = True
+        frontend_thread.start()
+        
+        print("\nPress Ctrl+C to stop the servers...")
+        # Keep the main thread alive
+        frontend_thread.join()
+        
+    except KeyboardInterrupt:
+        print("\nShutting down servers...")
+        frontend_server.stop()
+        GraphServer.stop_server()
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
Adds a development server setup that allows testing queries against live Spanner databases, independent of Jupyter, and supports local debugging.

https://github.com/user-attachments/assets/c9b541f7-5406-42e6-9551-a9dceba0613f

Key changes:
- New `dev.html` with connection settings form and query editor
- `serve_dev.py` runs both frontend and backend servers
- Development setup documentation

Testing:
1. `cd spanner_graphs/dev_util`
2. `python serve_dev.py`
3. Visit http://localhost:8000/static/dev.html
4. Configure connection settings and run queries