### PR TITLE
fix: Ensure color inconsistency between schema and regular nodes

### DIFF
--- a/frontend/src/spanner-config.js
+++ b/frontend/src/spanner-config.js
@@ -159,8 +159,10 @@ class GraphConfig {
     constructor({ nodesData, edgesData, colorPalette, colorScheme, rowsData, schemaData, queryResult}) {
         this.nodes = this.parseNodes(nodesData);
         this.edges = this.parseEdges(edgesData);
-        this.nodeColors = this.assignColors(this.nodes);
         this.parseSchema(schemaData);
+
+        this.nodeColors = {};
+        this.assignColors();
 
         if (colorPalette && Array.isArray(colorPalette)) {
             this.colorPalette = colorPalette;
@@ -175,41 +177,36 @@ class GraphConfig {
     }
 
     /**
-     * @param nodes
-     * @returns {{}} Color map by the node's label
+     * Assigns colors for node labels to the existing color map
      */
-    assignColors(nodes) {
-        const colors = {};
+    assignColors() {
         const colorPalette = this.colorPalette.map(color => color);
 
-        if (!nodes || !nodes instanceof Array) {
-            console.error('Nodes must be array', nodes);
-            throw Error('Nodes must be an array');
+        const labels = new Set();
+
+        for (const node of this.nodes) {
+            labels.add(node.label);
         }
 
-        nodes.forEach(node => {
+        for (const schemaNode of this.schemaNodes) {
+            labels.add(schemaNode.label);
+        }
+
+        for (const label of labels) {
             if (colorPalette.length === 0) {
                 console.error('Node labels exceed the color palette. Assigning default color.');
-                return;
+                continue;
             }
 
-            if (!node || !node instanceof Node) {
-                console.error('Object is not an instance of Node', node);
-                return;
-            }
-
-            const label = node.label;
             if (!label || !label instanceof String) {
                 console.error('Node does not have a label', node);
-                return;
+                continue;
             }
 
-            if (!colors[label]) {
-                colors[label] = colorPalette.shift();
+            if (!this.nodeColors[label]) {
+                this.nodeColors[label] = colorPalette.shift();
             }
-        });
-
-        return colors;
+        }
     }
 
     /**
@@ -269,7 +266,6 @@ class GraphConfig {
                 };
         });
         this.schemaEdges = this.parseEdges(edgesData);
-        this.schemaNodeColors = this.assignColors(this.schemaNodes);
     }
 
     /**

--- a/frontend/src/spanner-store.js
+++ b/frontend/src/spanner-store.js
@@ -339,19 +339,9 @@ class GraphStore {
             console.error('Node must have a label', node);
         }
 
-        switch (this.config.viewMode) {
-            case GraphConfig.ViewModes.SCHEMA:
-                const schemaColor = this.config.schemaNodeColors[node.label];
-                if (schemaColor) {
-                    return schemaColor;
-                }
-                break;
-            case GraphConfig.ViewModes.DEFAULT:
-                const nodeColor = this.config.nodeColors[node.label];
-                if (nodeColor) {
-                    return nodeColor;
-                }
-                break;
+        const nodeColor = this.config.nodeColors[node.label];
+        if (nodeColor) {
+            return nodeColor;
         }
 
         return 'rgb(100, 100, 100)';

--- a/frontend/tests/unit/graph-server.test.ts
+++ b/frontend/tests/unit/graph-server.test.ts
@@ -85,10 +85,12 @@ describe('GraphServer', () => {
             const originalLocation = window.location;
             // @ts-ignore
             delete window.location;
+            // @ts-ignore
             window.location = { ...originalLocation, hostname: 'vertex-ai-workbench' };
             const route = graphServer.buildRoute('/test-endpoint');
             expect(route).toBe('/proxy/8000/test-endpoint');
 
+            // @ts-ignore
             window.location = originalLocation;
         });
     });

--- a/frontend/tests/unit/spanner-config.test.ts
+++ b/frontend/tests/unit/spanner-config.test.ts
@@ -26,11 +26,29 @@ const Schema = require('../../src/models/schema.js');
 
 describe('GraphConfig', () => {
     // @ts-ignore
-    let mockNodesData;
+    let mockNodesData: Array<{
+        id: number;
+        label: string;
+        properties: Record<string, any>;
+        key_property_names: string[];
+    }>;
     // @ts-ignore
     let mockEdgesData;
     // @ts-ignore
-    let mockSchemaData;
+    let mockSchemaData: {
+        nodeTables: Array<{
+            name: string;
+            labelNames: string[];
+            columns: Array<{name: string; type: string}>;
+        }>;
+        edgeTables: Array<{
+            name: string;
+            labelNames: string[];
+            columns: Array<{name: string; type: string}>;
+            sourceNodeTable: {nodeTableName: string};
+            destinationNodeTable: {nodeTableName: string};
+        }>;
+    };
 
     beforeEach(() => {
         mockNodesData = [
@@ -191,7 +209,7 @@ describe('GraphConfig', () => {
     });
 
     describe('assignColors', () => {
-        it('should assign unique colors to different node labels', () => {
+        it('should append colors to different node labels', () => {
             const config = new GraphConfig({
                 // @ts-ignore
                 nodesData: mockNodesData,
@@ -228,6 +246,249 @@ describe('GraphConfig', () => {
 
             expect(Object.keys(config.nodeColors).length).toBe(2);
         });
+
+        it('should ensure schema nodes and default nodes with the same label have the same color', () => {
+            // Create a more complex scenario where:
+            // Regular nodes have labels: A, C, E, F
+            // Schema nodes have labels: A, B, C, D, E, F
+            const complexNodesData = [
+                {
+                    id: 1,
+                    label: 'A',
+                    properties: {name: 'Node A', value: 10},
+                    key_property_names: ['id']
+                },
+                {
+                    id: 2,
+                    label: 'C',
+                    properties: {name: 'Node C', value: 30},
+                    key_property_names: ['id']
+                },
+                {
+                    id: 3,
+                    label: 'E',
+                    properties: {name: 'Node E', value: 50},
+                    key_property_names: ['id']
+                },
+                {
+                    id: 4,
+                    label: 'F',
+                    properties: {name: 'Node F', value: 60},
+                    key_property_names: ['id']
+                }
+            ];
+
+            const complexSchemaData = {
+                nodeTables: [
+                    {
+                        name: 'TableA',
+                        labelNames: ['A'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    },
+                    {
+                        name: 'TableB',
+                        labelNames: ['B'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    },
+                    {
+                        name: 'TableC',
+                        labelNames: ['C'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    },
+                    {
+                        name: 'TableD',
+                        labelNames: ['D'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    },
+                    {
+                        name: 'TableE',
+                        labelNames: ['E'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    },
+                    {
+                        name: 'TableF',
+                        labelNames: ['F'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'value', type: 'INT64'}
+                        ]
+                    }
+                ],
+                edgeTables: []
+            };
+
+            const config = new GraphConfig({
+                // @ts-ignore
+                nodesData: complexNodesData,
+                edgesData: [],
+                // @ts-ignore
+                schemaData: complexSchemaData
+            });
+
+            // Verify that colors have been assigned to all labels
+            expect(Object.keys(config.nodeColors).sort()).toEqual(['A', 'B', 'C', 'D', 'E', 'F'].sort());
+        });
+
+        it('should maintain color consistency when adding new nodes with existing labels', () => {
+            // First create a config with schema nodes and some default nodes
+            const extendedSchemaData = {
+                nodeTables: [
+                    ...mockSchemaData.nodeTables,
+                    {
+                        name: 'Product',
+                        labelNames: ['Product'],
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'price', type: 'FLOAT64'}
+                        ]
+                    }
+                ],
+                edgeTables: mockSchemaData.edgeTables
+            };
+
+            const initialConfig = new GraphConfig({
+                // @ts-ignore
+                nodesData: mockNodesData, // Only Person and Company nodes
+                // @ts-ignore
+                edgesData: mockEdgesData,
+                // @ts-ignore
+                schemaData: extendedSchemaData
+            });
+
+            // Store the initial colors
+            const personColorInitial = initialConfig.nodeColors['Person'];
+            const companyColorInitial = initialConfig.nodeColors['Company'];
+            
+            // Now add a new node with an existing label (Person) and a new node with a schema-only label (Product)
+            const extendedNodesData = [
+                ...mockNodesData,
+                {
+                    id: 3,
+                    label: 'Person',
+                    properties: {name: 'Jane', age: 25},
+                    key_property_names: ['id']
+                },
+                {
+                    id: 4,
+                    label: 'Product',
+                    properties: {name: 'Laptop', price: 999.99},
+                    key_property_names: ['id']
+                }
+            ];
+
+            const updatedConfig = new GraphConfig({
+                // @ts-ignore
+                nodesData: extendedNodesData,
+                // @ts-ignore
+                edgesData: mockEdgesData,
+                // @ts-ignore
+                schemaData: extendedSchemaData
+            });
+
+            // Verify colors remain consistent
+            expect(updatedConfig.nodeColors['Person']).toBe(personColorInitial);
+            expect(updatedConfig.nodeColors['Company']).toBe(companyColorInitial);
+            expect(updatedConfig.nodeColors['Product']).toBe(updatedConfig.nodeColors['Product']);
+
+            // Verify that all node labels have colors
+            expect(Object.keys(updatedConfig.nodeColors).length).toBe(3);
+        });
+
+        it('should synchronize colors when schema is loaded after nodes', () => {
+            // Create a config with only nodes first (no schema)
+            const configWithoutSchema = new GraphConfig({
+                // @ts-ignore
+                nodesData: mockNodesData,
+                // @ts-ignore
+                edgesData: mockEdgesData,
+                schemaData: null
+            });
+
+            // Store the initial node colors
+            const personColorInitial = configWithoutSchema.nodeColors['Person'];
+            const companyColorInitial = configWithoutSchema.nodeColors['Company'];
+            
+            // Now create a new config with the same nodes but add schema
+            const configWithSchema = new GraphConfig({
+                // @ts-ignore
+                nodesData: mockNodesData,
+                // @ts-ignore
+                edgesData: mockEdgesData,
+                // @ts-ignore
+                schemaData: mockSchemaData
+            });
+
+            // Verify that schema node colors match the previously assigned node colors
+            expect(configWithSchema.nodeColors['Person']).toBe(personColorInitial);
+            expect(configWithSchema.nodeColors['Company']).toBe(companyColorInitial);
+            
+            // Verify that node colors remain consistent
+            expect(configWithSchema.nodeColors['Person']).toBe(personColorInitial);
+            expect(configWithSchema.nodeColors['Company']).toBe(companyColorInitial);
+            
+            // Verify that all node labels have the same color in both nodeColors and schemaNodeColors
+            expect(configWithSchema.nodeColors['Person']).toBe(configWithSchema.nodeColors['Person']);
+            expect(configWithSchema.nodeColors['Company']).toBe(configWithSchema.nodeColors['Company']);
+        });
+
+        it('should handle multiple schema nodes with the same label correctly', () => {
+            // Create schema data with multiple node tables having the same label
+            const schemaWithDuplicateLabels = {
+                nodeTables: [
+                    ...mockSchemaData.nodeTables,
+                    {
+                        name: 'Customer',
+                        labelNames: ['Person'], // Same label as Person node
+                        columns: [
+                            {name: 'id', type: 'STRING'},
+                            {name: 'name', type: 'STRING'},
+                            {name: 'email', type: 'STRING'}
+                        ]
+                    }
+                ],
+                edgeTables: mockSchemaData.edgeTables
+            };
+
+            const config = new GraphConfig({
+                // @ts-ignore
+                nodesData: mockNodesData,
+                // @ts-ignore
+                edgesData: mockEdgesData,
+                // @ts-ignore
+                schemaData: schemaWithDuplicateLabels
+            });
+
+            // Verify that all schema nodes with the same label have the same color
+            const personSchemaNodes = config.nodeColors['Person'];
+            
+            // Verify that all Person schema nodes have the same color
+            expect(personSchemaNodes).toBe(config.nodeColors['Person']);
+            
+            // Verify that the default Person node has the same color as the schema Person nodes
+            expect(config.nodeColors['Person']).toBe(personSchemaNodes);
+        });
     });
 
     describe('parseSchema', () => {
@@ -244,7 +505,6 @@ describe('GraphConfig', () => {
             expect(config.schema).toBeInstanceOf(Schema);
             expect(config.schemaNodes.length).toBe(2);
             expect(config.schemaEdges.length).toBe(1);
-            expect(config.schemaNodeColors).toBeDefined();
         });
 
         it('should handle missing schema data gracefully', () => {

--- a/frontend/tests/unit/spanner-store.test.ts
+++ b/frontend/tests/unit/spanner-store.test.ts
@@ -252,6 +252,62 @@ describe('GraphStore', () => {
             const color = store.getColorForNodeByLabel(mockNode1);
             expect(color).toBe('red');
         });
+
+        it('should return the same color for schema nodes and default nodes with the same label', () => {
+            // Create nodes with labels A, C, E, F
+            const nodeA = new GraphNode({id: '1', label: 'A'});
+            const nodeC = new GraphNode({id: '2', label: 'C'});
+            const nodeE = new GraphNode({id: '3', label: 'E'});
+            const nodeF = new GraphNode({id: '4', label: 'F'});
+            
+            // Create schema nodes with labels A, B, C, D, E, F
+            const schemaNodeA = new GraphNode({id: 's1', label: 'A', isSchema: true});
+            const schemaNodeB = new GraphNode({id: 's2', label: 'B', isSchema: true});
+            const schemaNodeC = new GraphNode({id: 's3', label: 'C', isSchema: true});
+            const schemaNodeD = new GraphNode({id: 's4', label: 'D', isSchema: true});
+            const schemaNodeE = new GraphNode({id: 's5', label: 'E', isSchema: true});
+            const schemaNodeF = new GraphNode({id: 's6', label: 'F', isSchema: true});
+            
+            // Setup a mock config with the complex scenario
+            const mockComplexNodesData = [
+                {id: '1', label: 'A', properties: {}, key_property_names: ['id']},
+                {id: '2', label: 'C', properties: {}, key_property_names: ['id']},
+                {id: '3', label: 'E', properties: {}, key_property_names: ['id']},
+                {id: '4', label: 'F', properties: {}, key_property_names: ['id']}
+            ];
+            
+            const mockComplexSchemaData = {
+                nodeTables: [
+                    {name: 'TableA', labelNames: ['A'], columns: []},
+                    {name: 'TableB', labelNames: ['B'], columns: []},
+                    {name: 'TableC', labelNames: ['C'], columns: []},
+                    {name: 'TableD', labelNames: ['D'], columns: []},
+                    {name: 'TableE', labelNames: ['E'], columns: []},
+                    {name: 'TableF', labelNames: ['F'], columns: []}
+                ],
+                edgeTables: []
+            };
+            
+            // Create a new config with our test data
+            const complexConfig = new GraphConfig({
+                nodesData: mockComplexNodesData,
+                edgesData: [],
+                schemaData: mockComplexSchemaData
+            });
+            
+            // Create a new store with this config
+            const complexStore = new GraphStore(complexConfig);
+            
+            // Verify that regular nodes and schema nodes with the same label get the same color
+            expect(complexStore.getColorForNodeByLabel(nodeA)).toBe(complexStore.getColorForNodeByLabel(schemaNodeA));
+            expect(complexStore.getColorForNodeByLabel(nodeC)).toBe(complexStore.getColorForNodeByLabel(schemaNodeC));
+            expect(complexStore.getColorForNodeByLabel(nodeE)).toBe(complexStore.getColorForNodeByLabel(schemaNodeE));
+            expect(complexStore.getColorForNodeByLabel(nodeF)).toBe(complexStore.getColorForNodeByLabel(schemaNodeF));
+            
+            // Verify that schema-only nodes (B, D) still have colors assigned
+            expect(complexStore.getColorForNodeByLabel(schemaNodeB)).toBeDefined();
+            expect(complexStore.getColorForNodeByLabel(schemaNodeD)).toBeDefined();
+        });
     });
 
     describe('Graph Navigation', () => {


### PR DESCRIPTION
fixes #28 

## Problem
Schema nodes and regular nodes with the same label were assigned different colors due to separate color assignment processes.

## Solution
- Replaced separate nodeColors and schemaNodeColors maps with a single nodeColors map
- Implemented appendColors method to build a unified color map

## Testing
Added tests for GraphConfig and GraphStore that verify nodes with the same label have the same color regardless of whether they're schema or regular nodes.