### PR TITLE
fix(colab): Fixed broken Colab handler for node expansion

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -164,6 +164,11 @@ class SpannerApp {
                                     return;
                                 }
 
+                                if (data.error) {
+                                    this.graph.showErrorStateForNode(node, error);
+                                    return;
+                                }
+
                                 const newData = this.store.appendGraphData(data.response.nodes, data.response.edges)
                                 if (newData) {
                                     // Show success message before appending data

--- a/frontend/src/graph-server.js
+++ b/frontend/src/graph-server.js
@@ -109,10 +109,7 @@ class GraphServer {
             }
         }
 
-        const {project, instance, database, graph} = JSON.parse(this.params);
-
         const request = {
-            project, instance, database, graph,
             uid: node.uid,
             node_labels: node.labels,
             node_properties: validProperties,
@@ -131,15 +128,12 @@ class GraphServer {
                 .finally(() => this.isFetching = false);
         }
 
-        // For non-Colab environment, combine params and request
-        const fullRequest = {
-            ...JSON.parse(this.params),
-            ...request
-        };
-
         return fetch(this.buildRoute(this.endpoints.postNodeExpansion), {
             method: 'POST',
-            body: JSON.stringify(fullRequest)
+            body: JSON.stringify({
+                params: this.params,
+                request
+            })
         })
             .then(response => {
                 if (!response.ok) {

--- a/frontend/tests/unit/graph-server.test.ts
+++ b/frontend/tests/unit/graph-server.test.ts
@@ -148,19 +148,23 @@ describe('GraphServer', () => {
                 {
                     method: 'POST',
                     body: JSON.stringify({
-                        project: 'test-project',
-                        instance: 'test-instance',
-                        database: 'test-database',
-                        graph: 'test-graph',
-                        mock: false,
-                        uid: 'node1',
-                        node_labels: ['TestLabel1'],
-                        node_properties: [{
-                            key: 'name',
-                            value: 'my-node-name',
-                            type: 'STRING'
-                        }],
-                        direction: 'OUTGOING'
+                        params: JSON.stringify({
+                            project: 'test-project',
+                            instance: 'test-instance',
+                            database: 'test-database',
+                            graph: 'test-graph',
+                            mock: false
+                        }),
+                        request: {
+                            uid: 'node1',
+                            node_labels: ['TestLabel1'],
+                            node_properties: [{
+                                key: 'name',
+                                value: 'my-node-name',
+                                type: 'STRING'
+                            }],
+                            direction: 'OUTGOING'
+                        }
                     })
                 }
             );

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -42,6 +42,17 @@ PROPERTY_TYPE_MAP = {
     'TIMESTAMP': TypeCode.TIMESTAMP
 }
 
+class NodeProperty:
+    def __init__(self, key: str, value: Union[str, int, float, bool], type: TypeCode):
+        self.key = key
+        self.value = value
+        self.type = type
+
+
+class EdgeDirection(Enum):
+    INCOMING = "INCOMING"
+    OUTGOING = "OUTGOING"
+
 def validate_property_type(property_type: str) -> TypeCode:
     """
     Validates and converts a property type string to a Spanner TypeCode.
@@ -68,15 +79,71 @@ def validate_property_type(property_type: str) -> TypeCode:
     
     return PROPERTY_TYPE_MAP[property_type]
 
-class EdgeDirection(Enum):
-    INCOMING = "INCOMING"
-    OUTGOING = "OUTGOING"
+def validate_node_expansion_request(data) -> (list[NodeProperty], EdgeDirection):
+    required_fields = ["project", "instance", "database", "graph", "uid", "node_labels", "direction"]
+    missing_fields = [field for field in required_fields if data.get(field) is None]
 
-class NodeProperty:
-    def __init__(self, key: str, value: Union[str, int, float, bool], type: TypeCode):
-        self.key = key
-        self.value = value
-        self.type = type
+    if missing_fields:
+        raise ValueError(f"Missing required fields: {', '.join(missing_fields)}")
+
+    node_labels = data.get("node_labels")
+    node_properties = data.get("node_properties", [])
+
+    # Validate node_labels
+    if not isinstance(node_labels, list):
+        raise ValueError("node_labels must be an array")
+
+    for label in node_labels:
+        if not isinstance(label, str):
+            raise ValueError("Each node label must be a string")
+
+    # Validate node_properties
+    if not isinstance(node_properties, list):
+        raise ValueError("node_properties must be an array")
+
+    validated_properties: list[NodeProperty] = []
+    for idx, prop in enumerate(node_properties):
+        if not isinstance(prop, dict):
+            raise ValueError(f"Property at index {idx} must be an object")
+
+        if not all(field in prop for field in ["key", "value", "type"]):
+            raise ValueError(f"Property at index {idx} is missing required fields (key, value, type)")
+
+        try:
+            prop_type_str = prop["type"]
+            if isinstance(prop_type_str, str):
+                prop_type = validate_property_type(prop_type_str)
+
+                value = prop["value"]
+                if prop_type in (TypeCode.INT64, TypeCode.NUMERIC):
+                    if not (isinstance(value, int) or (isinstance(value, str) and value.isdigit())):
+                        raise ValueError(f"Property '{prop['key']}' value must be a number for type {prop_type_str}")
+                elif prop_type in (TypeCode.FLOAT32, TypeCode.FLOAT64):
+                    try:
+                        float(value)
+                    except (ValueError, TypeError):
+                        raise ValueError(
+                            f"Property '{prop['key']}' value must be a valid float for type {prop_type_str}")
+                elif prop_type == TypeCode.BOOL:
+                    if not isinstance(value, bool) and not (isinstance(value, str) and value.lower() in ["true", "false"]):
+                        raise ValueError(f"Property '{prop['key']}' value must be a boolean for type {prop_type_str}")
+
+                validated_properties.append(NodeProperty(
+                    key=prop["key"],
+                    value=prop["value"],
+                    type=prop_type
+                ))
+            else:
+                raise ValueError(f"Property type at index {idx} must be a string")
+        except ValueError as e:
+            raise ValueError(f"Invalid property type in property at index {idx}: {str(e)}")
+
+    try:
+        direction = EdgeDirection(data.get("direction"))
+    except ValueError:
+        raise ValueError(f"Invalid direction: must be INCOMING or OUTGOING, got \"{data.get('direction')}\"")
+
+    return validated_properties, direction
 
 def execute_node_expansion(
     project: str,
@@ -232,6 +299,8 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         self.do_json_response(data)
 
     def do_error_response(self, message):
+        if isinstance(message, Exception):
+            message = str(message)
         self.do_json_response({'error': message})
 
     def parse_post_data(self):
@@ -259,98 +328,32 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         self.do_data_response(response)
 
     def handle_post_node_expansion(self):
-        data = self.parse_post_data()
-        required_fields = ["project", "instance", "database", "graph", "uid", "node_labels", "direction"]
-        missing_fields = [field for field in required_fields if data.get(field) is None]
-        
-        if missing_fields:
-            self.do_error_response(f"Missing required fields: {', '.join(missing_fields)}")
-            return
-
-        project = data.get("project")
-        instance = data.get("instance")
-        database = data.get("database")
-        graph = data.get("graph")
-        uid = data.get("uid")
-        node_labels = data.get("node_labels")
-        node_properties = data.get("node_properties", [])
-        edge_label = data.get("edge_label")
-
-        # Validate node_labels
-        if not isinstance(node_labels, list):
-            self.do_error_response("node_labels must be an array")
-            return
-
-        for label in node_labels:
-            if not isinstance(label, str):
-                self.do_error_response("Each node label must be a string")
-                return
-
-        # Validate node_properties
-        if not isinstance(node_properties, list):
-            self.do_error_response("node_properties must be an array")
-            return
-            
-        validated_properties: list[NodeProperty] = []
-        for idx, prop in enumerate(node_properties):
-            if not isinstance(prop, dict):
-                self.do_error_response(f"Property at index {idx} must be an object")
-                return
-                
-            if not all(field in prop for field in ["key", "value", "type"]):
-                self.do_error_response(f"Property at index {idx} is missing required fields (key, value, type)")
-                return
-                
-            try:
-                prop_type_str = prop["type"]
-                if isinstance(prop_type_str, str):
-                    prop_type = validate_property_type(prop_type_str)
-                    
-                    value = prop["value"]
-                    if prop_type in (TypeCode.INT64, TypeCode.NUMERIC):
-                        if not (isinstance(value, int) or (isinstance(value, str) and value.isdigit())):
-                            self.do_error_response(f"Property '{prop['key']}' value must be a number for type {prop_type_str}")
-                            return
-                    elif prop_type in (TypeCode.FLOAT32, TypeCode.FLOAT64):
-                        try:
-                            float(value)
-                        except (ValueError, TypeError):
-                            self.do_error_response(f"Property '{prop['key']}' value must be a valid float for type {prop_type_str}")
-                            return
-                    elif prop_type == TypeCode.BOOL:
-                        if not isinstance(value, bool) and not (isinstance(value, str) and value.lower() in ["true", "false"]):
-                            self.do_error_response(f"Property '{prop['key']}' value must be a boolean for type {prop_type_str}")
-                            return
-                    
-                    validated_properties.append(NodeProperty(
-                        key=prop["key"],
-                        value=prop["value"],
-                        type=prop_type
-                    ))
-                else:
-                    self.do_error_response(f"Property type at index {idx} must be a string")
-                    return
-            except ValueError as e:
-                self.do_error_response(f"Invalid property type in property at index {idx}: {str(e)}")
-                return
-        
         try:
-            direction = EdgeDirection(data.get("direction"))
-        except ValueError:
-            self.do_error_response(f"Invalid direction: must be INCOMING or OUTGOING, got \"{data.get('direction')}\"")
-            return
+            data = self.parse_post_data()
+            node_properties, direction = validate_node_expansion_request(data)
 
-        self.do_data_response(execute_node_expansion(
-            project=project, 
-            instance=instance, 
-            database=database,
-            node_labels=node_labels,
-            node_properties=validated_properties,
-            graph=graph, 
-            uid=uid,
-            direction=direction,
-            edge_label=edge_label,
-        ))
+            project = data.get("project")
+            instance = data.get("instance")
+            database = data.get("database")
+            graph = data.get("graph")
+            uid = data.get("uid")
+            node_labels = data.get("node_labels")
+            edge_label = data.get("edge_label")
+
+            self.do_data_response(execute_node_expansion(
+                project=project,
+                instance=instance,
+                database=database,
+                node_labels=node_labels,
+                node_properties=node_properties,
+                graph=graph,
+                uid=uid,
+                direction=direction,
+                edge_label=edge_label,
+            ))
+        except BaseException as e:
+            self.do_error_response(e)
+            return
 
     def do_GET(self):
         if self.path == GraphServer.endpoints["get_ping"]:

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -354,8 +354,8 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
             # - params_str: JSON string with connection parameters (project, instance, database, graph)
             # - request: Dict with node details (uid, node_labels, node_properties, direction, edge_label)
             self.do_data_response(execute_node_expansion(
-                params_str=data.get("params"),  # type: str - JSON string with connection parameters
-                request=data.get("request")     # type: dict - Node expansion request details
+                params_str=data.get("params"),
+                request=data.get("request")
             ))
         except BaseException as e:
             self.do_error_response(e)

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -92,30 +92,30 @@ def receive_query_request(query: str, params: str):
                               query=query,
                               mock=params_dict["mock"]))
 
-def receive_node_expansion_request(data: dict, params: str):
-    """Handle node expansion requests in Google Colab environment"""
+def receive_node_expansion_request(request: dict, params_str: str):
+    """Handle node expansion requests in Google Colab environment
+    
+    Args:
+        request: A dictionary containing node expansion details including:
+            - uid: str - Unique identifier of the node to expand
+            - node_labels: List[str] - Labels of the node
+            - node_properties: List[Dict] - Properties of the node with key, value, and type
+            - direction: str - Direction of expansion ("INCOMING" or "OUTGOING")
+            - edge_label: Optional[str] - Label of edges to filter by
+        params_str: A JSON string containing connection parameters:
+            - project: str - GCP project ID
+            - instance: str - Spanner instance ID
+            - database: str - Spanner database ID
+            - graph: str - Graph name
+            - mock: bool - Whether to use mock data
+    
+    Returns:
+        JSON: A JSON-serialized response containing either:
+            - The query results with nodes and edges
+            - An error message if the request failed
+    """
     try:
-        params_dict = json.loads(params)
-        node_properties, direction = validate_node_expansion_request(data)
-        project = params_dict.get("project")
-        instance = params_dict.get("instance")
-        database = params_dict.get("database")
-        graph = params_dict.get("graph")
-        uid = data.get("uid")
-        node_labels = data.get("node_labels")
-        edge_label = data.get("edge_label")
-
-        return JSON(execute_node_expansion(
-            project=project,
-            instance=instance,
-            database=database,
-            node_labels=node_labels,
-            node_properties=node_properties,
-            graph=graph,
-            uid=uid,
-            direction=direction,
-            edge_label=edge_label,
-        ))
+        return JSON(execute_node_expansion(params_str, request))
     except BaseException as e:
         return JSON({"error": e})
 

--- a/tests/graph_server_test.py
+++ b/tests/graph_server_test.py
@@ -1,13 +1,11 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from google.cloud.spanner_v1 import TypeCode
+import json
 
 from spanner_graphs.graph_server import (
     validate_property_type,
     execute_node_expansion,
-    EdgeDirection,
-    PROPERTY_TYPE_MAP,
-    NodeProperty
 )
 
 class TestPropertyTypeHandling(unittest.TestCase):
@@ -65,38 +63,42 @@ class TestPropertyTypeHandling(unittest.TestCase):
         
         test_cases = [
             # Numeric types (unquoted)
-            (TypeCode.INT64, "123", "123"),
-            (TypeCode.NUMERIC, "123.45", "123.45"),
-            (TypeCode.FLOAT32, "123.45", "123.45"),
-            (TypeCode.FLOAT64, "123.45", "123.45"),
+            ("INT64", "123", "123"),
+            ("NUMERIC", "123", "123"),
+            ("FLOAT32", "123.45", "123.45"),
+            ("FLOAT64", "123.45", "123.45"),
             # Boolean (unquoted)
-            (TypeCode.BOOL, "true", "true"),
+            ("BOOL", "true", "true"),
             # String types (quoted)
-            (TypeCode.STRING, "hello", '"hello"'),
-            (TypeCode.DATE, "2024-03-14", '"2024-03-14"'),
-            (TypeCode.TIMESTAMP, "2024-03-14T12:00:00Z", '"2024-03-14T12:00:00Z"'),
-            (TypeCode.BYTES, "base64data", '"base64data"'),
-            (TypeCode.ENUM, "ENUM_VALUE", '"ENUM_VALUE"'),
+            ("STRING", "hello", '"hello"'),
+            ("DATE", "2024-03-14", '"2024-03-14"'),
+            ("TIMESTAMP", "2024-03-14T12:00:00Z", '"2024-03-14T12:00:00Z"'),
+            ("BYTES", "base64data", '"base64data"'),
+            ("ENUM", "ENUM_VALUE", '"ENUM_VALUE"'),
         ]
         
-        base_args = {
+        params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
             "database": "test-database",
             "graph": "test-graph",
-            "uid": "test-uid",
-            "node_labels": ["Person"],
-            "direction": EdgeDirection.OUTGOING,
-        }
+        })
         
-        for type_code, value, expected_format in test_cases:
-            with self.subTest(type=type_code, value=value):
-                # Create a NodeProperty with the test value and type
-                prop = NodeProperty(key="test_property", value=value, type=type_code)
+        for type_str, value, expected_format in test_cases:
+            with self.subTest(type=type_str, value=value):
+                # Create a property dictionary
+                prop_dict = {"key": "test_property", "value": value, "type": type_str}
+                
+                request = {
+                    "uid": "test-uid",
+                    "node_labels": ["Person"],
+                    "node_properties": [prop_dict],
+                    "direction": "OUTGOING"
+                }
                 
                 execute_node_expansion(
-                    **base_args,
-                    node_properties=[prop]
+                    params_str=params,
+                    request=request
                 )
                 
                 # Extract the actual formatted value from the query
@@ -107,25 +109,33 @@ class TestPropertyTypeHandling(unittest.TestCase):
                 where_line = [line for line in query.split('\n') if 'WHERE' in line][0]
                 expected_pattern = f"n.test_property={expected_format}"
                 self.assertIn(expected_pattern, where_line,
-                    f"Expected property value pattern {expected_pattern} not found in WHERE clause for type {type_code}")
+                    f"Expected property value pattern {expected_pattern} not found in WHERE clause for type {type_str}")
                     
     @patch('spanner_graphs.graph_server.execute_query')
     def test_property_value_formatting_no_type(self, mock_execute_query):
         """Test that property values are quoted when no type is provided."""
         mock_execute_query.return_value = {"response": {"nodes": [], "edges": []}}
         
-        # Create a NodeProperty with no type specified
-        prop = NodeProperty(key="test_property", value="test_value", type=None)
+        # Create a property dictionary with string type (since null type is not allowed)
+        prop_dict = {"key": "test_property", "value": "test_value", "type": "STRING"}
+        
+        params = json.dumps({
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test-graph",
+        })
+        
+        request = {
+            "uid": "test-uid",
+            "node_labels": ["Person"],
+            "node_properties": [prop_dict],
+            "direction": "OUTGOING"
+        }
         
         execute_node_expansion(
-            project="test-project",
-            instance="test-instance",
-            database="test-database",
-            graph="test-graph",
-            uid="test-uid",
-            node_labels=["Person"],
-            node_properties=[prop],
-            direction=EdgeDirection.OUTGOING
+            params_str=params,
+            request=request
         )
         
         # Extract the actual formatted value from the query
@@ -134,7 +144,7 @@ class TestPropertyTypeHandling(unittest.TestCase):
         where_line = [line for line in query.split('\n') if 'WHERE' in line][0]
         expected_pattern = 'n.test_property="test_value"'
         self.assertIn(expected_pattern, where_line,
-            "Property value should be quoted when no type is provided")
+            "Property value should be quoted when string type is provided")
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/graph_server_test.py
+++ b/tests/graph_server_test.py
@@ -6,7 +6,8 @@ from spanner_graphs.graph_server import (
     validate_property_type,
     execute_node_expansion,
     EdgeDirection,
-    PROPERTY_TYPE_MAP
+    PROPERTY_TYPE_MAP,
+    NodeProperty
 )
 
 class TestPropertyTypeHandling(unittest.TestCase):
@@ -84,16 +85,18 @@ class TestPropertyTypeHandling(unittest.TestCase):
             "database": "test-database",
             "graph": "test-graph",
             "uid": "test-uid",
-            "node_key_property_name": "test_property",
+            "node_labels": ["Person"],
             "direction": EdgeDirection.OUTGOING,
         }
         
         for type_code, value, expected_format in test_cases:
             with self.subTest(type=type_code, value=value):
+                # Create a NodeProperty with the test value and type
+                prop = NodeProperty(key="test_property", value=value, type=type_code)
+                
                 execute_node_expansion(
                     **base_args,
-                    node_key_property_value=value,
-                    property_type=type_code
+                    node_properties=[prop]
                 )
                 
                 # Extract the actual formatted value from the query
@@ -102,13 +105,17 @@ class TestPropertyTypeHandling(unittest.TestCase):
                 
                 # Find the WHERE clause in the query and extract the value
                 where_line = [line for line in query.split('\n') if 'WHERE' in line][0]
-                self.assertIn(f"= {expected_format}", where_line,
-                    f"Expected value {value} to be formatted as {expected_format} for type {type_code}")
-
+                expected_pattern = f"n.test_property={expected_format}"
+                self.assertIn(expected_pattern, where_line,
+                    f"Expected property value pattern {expected_pattern} not found in WHERE clause for type {type_code}")
+                    
     @patch('spanner_graphs.graph_server.execute_query')
     def test_property_value_formatting_no_type(self, mock_execute_query):
         """Test that property values are quoted when no type is provided."""
         mock_execute_query.return_value = {"response": {"nodes": [], "edges": []}}
+        
+        # Create a NodeProperty with no type specified
+        prop = NodeProperty(key="test_property", value="test_value", type=None)
         
         execute_node_expansion(
             project="test-project",
@@ -116,18 +123,18 @@ class TestPropertyTypeHandling(unittest.TestCase):
             database="test-database",
             graph="test-graph",
             uid="test-uid",
-            node_key_property_name="test_property",
-            node_key_property_value="test_value",
-            direction=EdgeDirection.OUTGOING,
-            property_type=None
+            node_labels=["Person"],
+            node_properties=[prop],
+            direction=EdgeDirection.OUTGOING
         )
         
         # Extract the actual formatted value from the query
         last_call = mock_execute_query.call_args[0]
         query = last_call[3]
         where_line = [line for line in query.split('\n') if 'WHERE' in line][0]
-        self.assertIn('= "test_value"', where_line,
-            "Value should be quoted when no type is provided")
+        expected_pattern = 'n.test_property="test_value"'
+        self.assertIn(expected_pattern, where_line,
+            "Property value should be quoted when no type is provided")
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/node_expansion_test.py
+++ b/tests/node_expansion_test.py
@@ -58,11 +58,8 @@ class TestNodeExpansion(unittest.TestCase):
         # Call the function
         result = receive_node_expansion_request(request, params)
         
-        # Verify validate_node_expansion_request was called
-        mock_validate.assert_called_once_with(request)
-        
         # Verify execute_node_expansion was called with correct parameters
-        mock_execute.assert_called_once()
+        mock_execute.assert_called_once_with(params, request)
         
         # Verify the result is wrapped in JSON
         self.assertEqual(result.data, mock_execute.return_value)
@@ -102,11 +99,8 @@ class TestNodeExpansion(unittest.TestCase):
         # Call the function
         result = receive_node_expansion_request(request, params)
         
-        # Verify validate_node_expansion_request was called
-        mock_validate.assert_called_once_with(request)
-        
         # Verify execute_node_expansion was called with correct parameters
-        mock_execute.assert_called_once()
+        mock_execute.assert_called_once_with(params, request)
         
         # Verify the result is wrapped in JSON
         self.assertEqual(result.data, mock_execute.return_value)

--- a/tests/node_expansion_test.py
+++ b/tests/node_expansion_test.py
@@ -23,84 +23,149 @@ class TestNodeExpansion(unittest.TestCase):
             "mock": False
         })
 
+    @patch('spanner_graphs.magics.validate_node_expansion_request')
     @patch('spanner_graphs.magics.execute_node_expansion')
-    def test_receive_node_expansion_request(self, mock_execute):
-        # Setup mock return value
+    def test_receive_node_expansion_request(self, mock_execute, mock_validate):
+        """Test that the receive_node_expansion_request function correctly processes requests."""
+        # Setup mock return values
+        mock_validate.return_value = ([], EdgeDirection.OUTGOING)
         mock_execute.return_value = {
             "response": {
                 "nodes": [],
                 "edges": []
             }
         }
-
+        
+        # Create request and params objects
+        request = {
+            "uid": "node-123",
+            "node_labels": ["Person"],
+            "node_properties": [
+                {"key": "id", "value": "123", "type": "INT64"}
+            ],
+            "direction": "OUTGOING",
+            "edge_label": "CONNECTS_TO"
+        }
+        
+        params = json.dumps({
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test_graph",
+            "mock": False
+        })
+        
         # Call the function
-        result = receive_node_expansion_request(self.sample_request, self.sample_params)
-
+        result = receive_node_expansion_request(request, params)
+        
+        # Verify validate_node_expansion_request was called
+        mock_validate.assert_called_once_with(request)
+        
         # Verify execute_node_expansion was called with correct parameters
-        mock_execute.assert_called_once_with(
-            project="test-project",
-            instance="test-instance",
-            database="test-database",
-            graph="test_graph",
-            uid="node-123",
-            node_key_property_name="id",
-            node_key_property_value="123",
-            direction=EdgeDirection.OUTGOING,
-            edge_label="CONNECTS_TO",
-            property_type=TypeCode.INT64
-        )
-
+        mock_execute.assert_called_once()
+        
         # Verify the result is wrapped in JSON
         self.assertEqual(result.data, mock_execute.return_value)
 
+    @patch('spanner_graphs.magics.validate_node_expansion_request')
     @patch('spanner_graphs.magics.execute_node_expansion')
-    def test_receive_node_expansion_request_without_edge_label(self, mock_execute):
-        # Remove edge_label from request
-        request = dict(self.sample_request)
-        del request["edge_label"]
-
-        # Setup mock return value
+    def test_receive_node_expansion_request_without_edge_label(self, mock_execute, mock_validate):
+        """Test that the receive_node_expansion_request function correctly handles missing edge_label."""
+        # Setup mock return values
+        mock_validate.return_value = ([], EdgeDirection.OUTGOING)
         mock_execute.return_value = {
             "response": {
                 "nodes": [],
                 "edges": []
             }
         }
-
+        
+        # Create request without edge_label and params objects
+        request = {
+            "uid": "node-123",
+            "node_labels": ["Person"],
+            "node_properties": [
+                {"key": "id", "value": "123", "type": "INT64"}
+            ],
+            "direction": "OUTGOING"
+            # No edge_label
+        }
+        
+        params = json.dumps({
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test_graph",
+            "mock": False
+        })
+        
         # Call the function
-        result = receive_node_expansion_request(request, self.sample_params)
-
+        result = receive_node_expansion_request(request, params)
+        
+        # Verify validate_node_expansion_request was called
+        mock_validate.assert_called_once_with(request)
+        
         # Verify execute_node_expansion was called with correct parameters
-        mock_execute.assert_called_once_with(
-            project="test-project",
-            instance="test-instance",
-            database="test-database",
-            graph="test_graph",
-            uid="node-123",
-            node_key_property_name="id",
-            node_key_property_value="123",
-            direction=EdgeDirection.OUTGOING,
-            edge_label=None,
-            property_type=TypeCode.INT64
-        )
+        mock_execute.assert_called_once()
+        
+        # Verify the result is wrapped in JSON
+        self.assertEqual(result.data, mock_execute.return_value)
+        
+    @patch('spanner_graphs.magics.validate_node_expansion_request')
+    def test_invalid_property_type(self, mock_validate):
+        """Test that invalid property types are correctly caught."""
+        # Set up the mock to raise a ValueError when called with invalid data
+        mock_validate.side_effect = ValueError("Invalid property type")
+        
+        # Create a request with invalid property type
+        request = {
+            "uid": "node-123",
+            "node_labels": ["Person"],
+            "node_properties": [
+                {"key": "id", "value": "123", "type": "INVALID_TYPE"}
+            ],
+            "direction": "OUTGOING"
+        }
+        
+        params = json.dumps({
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test_graph",
+            "mock": False
+        })
 
-    def test_invalid_property_type(self):
-        # Modify request to have invalid property type
-        request = dict(self.sample_request)
-        request["node_key_property_type"] = "INVALID_TYPE"
+        # Call the function and verify it returns an error response
+        result = receive_node_expansion_request(request, params)
+        self.assertIn("error", result.data)
+        
+    @patch('spanner_graphs.magics.validate_node_expansion_request')
+    def test_invalid_direction(self, mock_validate):
+        """Test that invalid directions are correctly caught."""
+        # Set up the mock to raise a ValueError when called with invalid data
+        mock_validate.side_effect = ValueError("Invalid direction")
+        
+        # Create a request with invalid direction
+        request = {
+            "uid": "node-123",
+            "node_labels": ["Person"],
+            "node_properties": [
+                {"key": "id", "value": "123", "type": "INT64"}
+            ],
+            "direction": "INVALID_DIRECTION"
+        }
+        
+        params = json.dumps({
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test_graph",
+            "mock": False
+        })
 
-        # Verify it raises ValueError
-        with self.assertRaises(ValueError):
-            receive_node_expansion_request(request, self.sample_params)
-
-    def test_invalid_direction(self):
-        # Modify request to have invalid direction
-        request = dict(self.sample_request)
-        request["direction"] = "INVALID_DIRECTION"
-
-        # Verify it raises ValueError
-        with self.assertRaises(ValueError):
-            receive_node_expansion_request(request, self.sample_params)
+        # Call the function and verify it returns an error response
+        result = receive_node_expansion_request(request, params)
+        self.assertIn("error", result.data)
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -14,6 +14,7 @@
 
 import unittest
 import requests
+import json
 from spanner_graphs.graph_server import GraphServer
 
 class TestSpannerServer(unittest.TestCase):
@@ -39,13 +40,17 @@ class TestSpannerServer(unittest.TestCase):
         # Build the request URL
         route = GraphServer.build_route(GraphServer.endpoints["post_query"])
         
-        # Create request data
-        request_data = {
+        # Create request data with the new structure
+        params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
             "database": "test-database",
-            "query": "GRAPH TestGraph MATCH (n) RETURN n",
             "mock": True
+        })
+        
+        request_data = {
+            "params": params,
+            "query": "GRAPH TestGraph MATCH (n) RETURN n"
         }
 
         # Send POST request

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -82,5 +82,32 @@ class TestSpannerServer(unittest.TestCase):
         self.assertIn("source_node_identifier", edge)
         self.assertIn("destination_node_identifier", edge)
 
+    def test_node_expansion_error_handling(self):
+        """Test that errors in node expansion are properly handled and returned."""
+        # Build the request URL
+        route = GraphServer.build_route(GraphServer.endpoints["post_node_expansion"])
+        
+        # Create request data with invalid fields to trigger validation error
+        request_data = {
+            "project": "test-project",
+            "instance": "test-instance",
+            "database": "test-database",
+            "graph": "test-graph",
+            "uid": "test-uid",
+            # Missing required node_labels field
+            "direction": "INVALID_DIRECTION"  # Invalid direction
+        }
+
+        # Send POST request
+        response = requests.post(route, json=request_data)
+        
+        # Verify response
+        self.assertEqual(response.status_code, 200)  # Server still returns 200 but with error data
+        response_data = response.json()
+        
+        # Check error presence
+        self.assertIn("error", response_data)
+        self.assertIsNotNone(response_data["error"])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The Colab handler for node expansion was deprecated and was checking for parameters that no longer existed.

- Centralized validation between HTTP and Colab handlers
- Fixed Colab handler to check for the correct data
- Updated tests for validation and error handling