### PR TITLE
feat: Add support for intermediate placeholder nodes in graph visualization

### DIFF
--- a/frontend/src/models/node.js
+++ b/frontend/src/models/node.js
@@ -39,6 +39,13 @@ class Node extends GraphObject {
      */
     identifiers = [];
 
+    /**
+     * Denotes if the node was created in the absence of a node from the query response.
+     * This may happen when a query only returns edges. The edge has UIDs for a source/destination node,
+     * but no nodes were returned from the response.
+     * @type {boolean}
+     */
+    intermediate = false;
 
     /**
      * The following properties will be set by ForceGraph.
@@ -58,6 +65,7 @@ class Node extends GraphObject {
      * @property {Object} key_property_names
      * @property {string} color
      * @property {string} identifier
+     * @property {bool} intermediate
      */
 
     /**
@@ -65,11 +73,12 @@ class Node extends GraphObject {
     * @param {NodeData} params
     */
     constructor(params) {
-        const { labels, title, properties, value, key_property_names, identifier } = params;
+        const { labels, title, properties, value, key_property_names, identifier, intermediate } = params;
         super({ labels, title, properties, key_property_names, identifier });
 
         this.value = value;
         this.instantiated = true;
+        this.intermediate = intermediate || false;
 
         // Parse the human-readable unique identifiers that
         // distinguishes a node from its peers
@@ -80,6 +89,10 @@ class Node extends GraphObject {
                 }
             }
         }
+    }
+
+    isIntermediateNode() {
+        return this.intermediate;
     }
 }
 

--- a/frontend/src/spanner-config.js
+++ b/frontend/src/spanner-config.js
@@ -207,7 +207,7 @@ class GraphConfig {
 
         for (const uid of Object.keys(this.nodes)) {
             const node = this.nodes[uid];
-            if (!node || !(node instanceof Node)) {
+            if (!node || !(node instanceof Node) || node.isIntermediateNode()) {
                 continue;
             }
 
@@ -411,7 +411,8 @@ class GraphConfig {
         const newEdges = this.parseEdges(edgesData);
 
         for (const uid of Object.keys(newNodes)) {
-            if (!this.nodes[uid]) {
+            const existingNode = this.nodes[uid];
+            if (!(existingNode instanceof Node) || existingNode.isIntermediateNode()) {
                 this.nodes[uid] = newNodes[uid];
             }
         }

--- a/frontend/src/spanner-store.js
+++ b/frontend/src/spanner-store.js
@@ -450,9 +450,13 @@ class GraphStore {
      * @returns {string} The color for the node based on its label.
      */
     getColorForNodeByLabel(node) {
-        const defaultColor = 'rgb(100, 100, 100)';
+        const defaultColor = 'rgb(100, 100, 100)'
         if (!node || !(node instanceof Node)) {
             return defaultColor;
+        }
+
+        if (node.isIntermediateNode()) {
+            return 'rgb(128, 134, 139)';
         }
 
         const nodeColor = this.config.nodeColors[node.getLabels()];
@@ -489,7 +493,8 @@ class GraphStore {
         const newNodes = [];
         if (Array.isArray(nodesData)) {
             for (const nodeData of nodesData) {
-                if (this.config.nodes[nodeData.identifier]) {
+                const existingNode = this.config.nodes[nodeData.identifier];
+                if (existingNode && !existingNode.isIntermediateNode()) {
                     continue;
                 }
 

--- a/frontend/src/visualization/spanner-forcegraph.js
+++ b/frontend/src/visualization/spanner-forcegraph.js
@@ -1086,6 +1086,7 @@ class GraphVisualization {
                         }
 
                         const showLabel =
+                            !node.isIntermediateNode() && (
                             // The user has chosen to view labels
                             this.store.config.showLabels ||
                             // Always show labels in Schema view
@@ -1096,7 +1097,7 @@ class GraphVisualization {
                             this.selectedNodeNeighbors.includes(node) ||
                             this.focusedNodeNeighbors.includes(node) ||
                             this.focusedEdgeNeighbors.includes(node) ||
-                            this.selectedEdgeNeighbors.includes(node);
+                            this.selectedEdgeNeighbors.includes(node));
 
                         // Init label
                         ctx.save();
@@ -1438,7 +1439,7 @@ class GraphVisualization {
      */
     _showMouseContextMenu(node, event) {
         // Don't show context menu in schema mode
-        if (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA) {
+        if (this.store.config.viewMode === GraphConfig.ViewModes.SCHEMA || node.isIntermediateNode()) {
             return;
         }
 

--- a/frontend/src/visualization/spanner-sidebar.js
+++ b/frontend/src/visualization/spanner-sidebar.js
@@ -277,7 +277,9 @@ class SidebarConstructor {
         if (this.store.config.selectedGraphObject) {
             if (this.store.config.selectedGraphObject instanceof Node) {
                 this.properties();
-                this.expandNode();
+                if (!this.store.config.selectedGraphObject.isIntermediateNode()) {
+                    this.expandNode();
+                }
                 this.neighbors();
             } else {
                 this.neighbors();

--- a/frontend/tests/unit/models/node.test.ts
+++ b/frontend/tests/unit/models/node.test.ts
@@ -57,4 +57,32 @@ describe('Node', () => {
             expect(graphNode.identifiers).toEqual(['foo', 'boolean', 'zero']);
         });
     });
+
+    describe('Intermediate Nodes', () => {
+        it('should create a non-intermediate node by default', () => {
+            const graphNode = new GraphNode(validNodeData);
+            expect(graphNode.intermediate).toBe(false);
+            expect(graphNode.isIntermediateNode()).toBe(false);
+        });
+
+        it('should create an intermediate node when specified', () => {
+            const intermediateNodeData = {
+                ...validNodeData,
+                intermediate: true
+            };
+            const graphNode = new GraphNode(intermediateNodeData);
+            expect(graphNode.intermediate).toBe(true);
+            expect(graphNode.isIntermediateNode()).toBe(true);
+        });
+
+        it('should handle undefined intermediate flag', () => {
+            const nodeData = {
+                ...validNodeData,
+                intermediate: undefined
+            };
+            const graphNode = new GraphNode(nodeData);
+            expect(graphNode.intermediate).toBe(false);
+            expect(graphNode.isIntermediateNode()).toBe(false);
+        });
+    });
 });

--- a/frontend/tests/unit/spanner-config.test.ts
+++ b/frontend/tests/unit/spanner-config.test.ts
@@ -306,4 +306,73 @@ describe('GraphConfig', () => {
             expect(mockConfig.nodeCount).toBe(2);
         });
     });
+
+    describe('Intermediate Node Handling', () => {
+        test('should exclude intermediate nodes from color assignment', () => {
+            const mockConfig = new GraphConfig({
+                nodesData: [
+                    { identifier: "1", labels: ['Person'], properties: {} },
+                    { identifier: "2", labels: ['Movie'], properties: {}, intermediate: true }
+                ],
+                edgesData: [],
+                colorPalette: ['#FF0000'],
+                colorScheme: GraphConfig.ColorScheme.LABEL,
+                rowsData: [],
+                schemaData: {},
+                queryResult: {}
+            });
+
+            // Should only assign color to non-intermediate node
+            expect(Object.keys(mockConfig.nodeColors).length).toBe(1);
+            expect(mockConfig.nodeColors['Person']).toBeDefined();
+        });
+
+        test('should allow replacing intermediate nodes with real nodes', () => {
+            const mockConfig = new GraphConfig({
+                nodesData: [
+                    { identifier: "1", labels: ['Person'], properties: {}, intermediate: true }
+                ],
+                edgesData: [],
+                colorPalette: ['#FF0000'],
+                colorScheme: GraphConfig.ColorScheme.LABEL,
+                rowsData: [],
+                schemaData: {},
+                queryResult: {}
+            });
+
+            // Append a real node with the same identifier
+            mockConfig.appendGraphData([
+                { identifier: "1", labels: ['Person'], properties: { name: 'John' } }
+            ], []);
+
+            const node = mockConfig.nodes["1"];
+            expect(node).toBeDefined();
+            expect(node.isIntermediateNode()).toBe(false);
+            expect(node.properties.name).toBe('John');
+        });
+
+        test('should not replace real nodes with intermediate nodes', () => {
+            const mockConfig = new GraphConfig({
+                nodesData: [
+                    { identifier: "1", labels: ['Person'], properties: { name: 'John' } }
+                ],
+                edgesData: [],
+                colorPalette: ['#FF0000'],
+                colorScheme: GraphConfig.ColorScheme.LABEL,
+                rowsData: [],
+                schemaData: {},
+                queryResult: {}
+            });
+
+            // Try to append an intermediate node with the same identifier
+            mockConfig.appendGraphData([
+                { identifier: "1", labels: ['Person'], properties: {}, intermediate: true }
+            ], []);
+
+            const node = mockConfig.nodes["1"];
+            expect(node).toBeDefined();
+            expect(node.isIntermediateNode()).toBe(false);
+            expect(node.properties.name).toBe('John');
+        });
+    });
 });

--- a/frontend/tests/unit/spanner-store.test.ts
+++ b/frontend/tests/unit/spanner-store.test.ts
@@ -925,4 +925,86 @@ describe('GraphStore', () => {
         expect(store.getEdgeTypesOfNodeSorted(undefined)).toEqual([]);
         expect(store.getEdgeTypesOfNodeSorted({} as any)).toEqual([]);
     });
+
+    describe('Intermediate Node Handling', () => {
+        test('should return correct color for intermediate nodes', () => {
+            const intermediateNode = new GraphNode({
+                identifier: "1",
+                labels: ['Person'],
+                properties: {},
+                intermediate: true
+            });
+
+            const color = store.getColorForNodeByLabel(intermediateNode);
+            expect(color).toBe('rgb(128, 134, 139)');
+        });
+
+        test('should return correct color for non-intermediate nodes', () => {
+            const regularNode = new GraphNode({
+                identifier: "1",
+                labels: ['Person'],
+                properties: {}
+            });
+
+            // Set up the node color explicitly for the test
+            store.config.nodeColors['Person'] = '#FF0000';
+            
+            const color = store.getColorForNodeByLabel(regularNode);
+            expect(color).toBe('#FF0000'); // Now we expect the color we explicitly set
+        });
+
+        test('should handle node expansion requests for intermediate nodes', () => {
+            const intermediateNode = new GraphNode({
+                identifier: "1",
+                labels: ['Person'],
+                properties: {},
+                intermediate: true
+            });
+
+            // Mock the event listener
+            const mockCallback = jest.fn();
+            store.addEventListener(GraphStore.EventTypes.NODE_EXPANSION_REQUEST, mockCallback);
+
+            // Request expansion
+            store.requestNodeExpansion(intermediateNode, 'OUTGOING', 'CONNECTS_TO');
+
+            // Verify the callback was called with correct parameters
+            expect(mockCallback).toHaveBeenCalledWith(
+                intermediateNode,
+                'OUTGOING',
+                'CONNECTS_TO',
+                expect.any(Array),
+                expect.any(Object)
+            );
+        });
+
+        test('should handle node expansion requests for non-intermediate nodes', () => {
+            const regularNode = new GraphNode({
+                identifier: "1",
+                labels: ['Person'],
+                properties: { name: 'John' }
+            });
+
+            // Mock the event listener
+            const mockCallback = jest.fn();
+            store.addEventListener(GraphStore.EventTypes.NODE_EXPANSION_REQUEST, mockCallback);
+
+            // Request expansion
+            store.requestNodeExpansion(regularNode, 'OUTGOING', 'CONNECTS_TO');
+
+            // Verify the callback was called with correct parameters
+            expect(mockCallback).toHaveBeenCalledWith(
+                regularNode,
+                'OUTGOING',
+                'CONNECTS_TO',
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        key: 'name',
+                        value: 'John'
+                    })
+                ]),
+                expect.any(Object)
+            );
+        });
+    });
 });

--- a/spanner_graphs/conversion.py
+++ b/spanner_graphs/conversion.py
@@ -76,4 +76,17 @@ def get_nodes_edges(data: Dict[str, List[Any]], fields: List[StructType.Field], 
                     edge = Edge.from_json(item)
                     edges.append(edge)
 
+    # Create placeholder nodes for nodes that were not returned
+    # from the query but are identified in the edges
+    missing_node_identifiers = set()
+    for edge in edges:
+        if edge.source not in node_identifiers:
+            missing_node_identifiers.add(edge.source)
+        if edge.destination not in node_identifiers:
+            missing_node_identifiers.add(edge.destination)
+
+    for identifier in missing_node_identifiers:
+        nodes.append(Node.make_intermediate(identifier))
+        node_identifiers.add(identifier)
+
     return nodes, edges

--- a/spanner_graphs/graph_entities.py
+++ b/spanner_graphs/graph_entities.py
@@ -146,14 +146,16 @@ class Node:
         identifier (str): The unique identifier for the node.
         labels (List[str]): The labels associated with the node.
         properties (Dict[str, Any]): The properties of the node.
+        intermediate (bool): Determines if this node was generated outside of the query response
     """
 
     def __init__(self, identifier: str, labels: List[str],
-                 properties: Dict[str, Any]):
+                 properties: Dict[str, Any], intermediate = False):
         self.identifier = identifier
         self.labels = labels
         self.key_property_names = []
         self.properties = properties
+        self.intermediate = intermediate
 
     def __repr__(self):
         return (f"Node(identifier={self.identifier}, "
@@ -165,8 +167,19 @@ class Node:
             "identifier": self.identifier,
             "labels": self.labels,
             "properties": self.properties,
-            "key_property_names": self.key_property_names
+            "key_property_names": self.key_property_names,
+            "intermediate": self.intermediate
         }
+
+    @staticmethod
+    def make_intermediate(identifier: str):
+        """Create a Node instance in the absence of a node from the query response"""
+        return Node(
+            identifier=identifier,
+            labels=["Intermediate"],
+            properties={"note": "This node represents a referenced entity that wasn't returned in the query results."},
+            intermediate=True
+        )
 
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> Node:

--- a/tests/graph_entities_test.py
+++ b/tests/graph_entities_test.py
@@ -36,28 +36,47 @@ class TestNode(unittest.TestCase):
         self.assertEqual(node.identifier, "1")
         self.assertEqual(node.labels, ["Person"])
         self.assertEqual(node.properties, {"name": "Emmanuel"})
+        self.assertFalse(node.intermediate, "Node should not be intermediate by default")
 
-    def test_add_node_to_graph(self):
-        """Test that a node is added correctly to a networkx graph"""
-        graph = nx.MultiDiGraph()
-        node_mapping = {}
+    def test_intermediate_flag_in_constructor(self):
+        """Test that the intermediate flag is set correctly in the constructor"""
+        # Test with intermediate=True
+        node1 = Node("1", ["Person"], {"name": "Emmanuel"}, intermediate=True)
+        self.assertTrue(node1.intermediate, "Node should be marked as intermediate")
+        
+        # Test with intermediate=False
+        node2 = Node("2", ["Person"], {"name": "John"}, intermediate=False)
+        self.assertFalse(node2.intermediate, "Node should not be marked as intermediate")
+        
+        # Test with default (should be False)
+        node3 = Node("3", ["Person"], {"name": "Alice"})
+        self.assertFalse(node3.intermediate, "Node should default to not intermediate")
 
-        data = {
-            "identifier": "1",
-            "labels": ["Person"],
-            "properties": {
-                "name": "Emmanuel"
-            },
-        }
+    def test_make_intermediate(self):
+        """Test the make_intermediate static method"""
+        test_identifier = "test123"
+        node = Node.make_intermediate(test_identifier)
+        
+        self.assertEqual(node.identifier, test_identifier, "Identifier should match input")
+        self.assertEqual(node.labels, ["Intermediate"], "Labels should include 'Intermediate'")
+        self.assertTrue(node.intermediate, "Node should be marked as intermediate")
+        self.assertIn("note", node.properties, "Properties should include a note field")
+        self.assertTrue(
+            "referenced entity" in node.properties["note"],
+            "Note should explain this is a referenced entity"
+        )
 
-        node = Node.from_json(data)
-        if node.identifier not in node_mapping:
-            node_mapping[node.identifier] = len(node_mapping) + 1
-
-        node.add_to_graph(graph)
-
-        self.assertIn(node_mapping["1"], graph)
-        node_id = node_mapping["1"]
+    def test_to_json_with_intermediate(self):
+        """Test that to_json correctly includes the intermediate flag"""
+        # Test with intermediate=True
+        node1 = Node("1", ["Person"], {"name": "Jill"}, intermediate=True)
+        json1 = node1.to_json()
+        self.assertTrue(json1["intermediate"], "JSON should include intermediate=True")
+        
+        # Test with intermediate=False
+        node2 = Node("2", ["Person"], {"name": "John"}, intermediate=False)
+        json2 = node2.to_json()
+        self.assertFalse(json2["intermediate"], "JSON should include intermediate=False")
 
 class TestEdge(unittest.TestCase):
     """Test cases for the Edge class"""


### PR DESCRIPTION
```
match ()-[e]->() return TO_JSON(e) as edges LIMIT 5
```
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/643aa7e7-a078-42aa-b56d-4446b9e96b45" />

## Summary
This PR introduces the concept of "intermediate nodes" to improve visualization of partial graph data. When a query returns edges but not all the nodes those edges connect, the system now automatically creates placeholder nodes for the missing references, ensuring the graph remains connected and visually coherent.

These intermediate nodes are visually distinct (light gray color, no labels) and have limited interaction capabilities compared to real nodes, making it clear to users which parts of the graph are actual query results versus inferred placeholders.


## Changes
- Added `intermediate` flag to Node class in both frontend and backend
- Implemented automatic creation of placeholder nodes for missing node references in query results
- Added visual distinction for intermediate nodes (gray color, no labels)
- Disabled context menu and expansion options for intermediate nodes
- Ensured intermediate nodes are replaced when actual node data becomes available