### PR TITLE
GraphServer: Remove reliance on CloudSpanner's TypeCode

### DIFF
--- a/spanner_graphs/cloud_database.py
+++ b/spanner_graphs/cloud_database.py
@@ -117,7 +117,13 @@ class CloudSpannerDatabase(SpannerDatabase):
                 results = snapshot.execute_sql(query, params=params, param_types=param_types)
                 rows = list(results)
             except Exception as e:
-                return {}, [], [], self.schema_json, e
+                return SpannerQueryResult(
+                    data={},
+                    fields=[],
+                    rows=[],
+                    schema_json=self.schema_json,
+                    err=e
+                )
 
             fields: List[SpannerFieldInfo] = get_as_field_info_list(results.fields)
             data = {field.name: [] for field in fields}
@@ -128,7 +134,7 @@ class CloudSpannerDatabase(SpannerDatabase):
                     fields=fields,
                     rows=rows,
                     schema_json=self.schema_json,
-                    error=None
+                    err=None
                 )
 
             for row_data in rows:
@@ -143,5 +149,5 @@ class CloudSpannerDatabase(SpannerDatabase):
                 fields=fields,
                 rows=rows,
                 schema_json=self.schema_json,
-                error=None
+                err=None
             )

--- a/spanner_graphs/cloud_database.py
+++ b/spanner_graphs/cloud_database.py
@@ -1,0 +1,143 @@
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the cloud-specific implementation for talking to a Spanner database.
+"""
+
+from __future__ import annotations
+import json
+from typing import Any, Dict, List, Tuple
+
+from google.cloud import spanner
+from google.cloud.spanner_v1 import JsonObject
+from google.api_core.client_options import ClientOptions
+from google.cloud.spanner_v1.types import StructType, Type
+import pydata_google_auth
+
+from spanner_graphs.database import SpannerDatabase, MockSpannerDatabase, SpannerQueryResult, SpannerFieldInfo, get_as_field_info_list
+
+def _get_default_credentials_with_project():
+    return pydata_google_auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"], use_local_webserver=False)
+
+class CloudSpannerDatabase(SpannerDatabase):
+    """Concrete implementation for Spanner database on the cloud."""
+    def __init__(self, project_id: str, instance_id: str,
+                 database_id: str) -> None:
+        credentials, _ = _get_default_credentials_with_project()
+        self.client = spanner.Client(
+            project=project_id, credentials=credentials, client_options=ClientOptions(quota_project_id=project_id))
+        self.instance = self.client.instance(instance_id)
+        self.database = self.instance.database(database_id)
+        self.schema_json: Any | None = None
+
+    def __repr__(self) -> str:
+        return (f"<CloudSpannerDatabase["
+                f"project:{self.client.project_name},"
+                f"instance:{self.instance.name},"
+                f"db:{self.database.name}]>")
+
+    def _extract_graph_name(self, query: str) -> str:
+        words = query.strip().split()
+        if len(words) < 3:
+            raise ValueError("invalid query: must contain at least (GRAPH, graph_name and query)")
+
+        if words[0].upper() != "GRAPH":
+            raise ValueError("invalid query: GRAPH must be the first word")
+
+        return words[1]
+
+    def _get_schema_for_graph(self, graph_query: str) -> Any | None:
+        try:
+            graph_name = self._extract_graph_name(graph_query)
+        except ValueError:
+            return None
+
+        with self.database.snapshot() as snapshot:
+            schema_query = """
+            SELECT property_graph_name, property_graph_metadata_json
+            FROM information_schema.property_graphs
+            WHERE property_graph_name = @graph_name
+            """
+            params = {"graph_name": graph_name}
+            param_type = {"graph_name": spanner.param_types.STRING}
+
+            result = snapshot.execute_sql(schema_query, params=params, param_types=param_type)
+            schema_rows = list(result)
+
+            if schema_rows:
+                return schema_rows[0][1]
+            else:
+                return None
+
+    def execute_query(
+        self,
+        query: str,
+        limit: int = None,
+        is_test_query: bool = False,
+    ) -> SpannerQueryResult:
+        """
+        This method executes the provided `query`
+
+        Args:
+            query: The SQL query to execute against the database
+            limit: An optional limit for the number of rows to return
+            is_test_query: If true, skips schema fetching for graph queries.
+
+        Returns:
+            A `SpannerQueryResult`
+        """
+        self.schema_json = None
+        if not is_test_query:
+            self.schema_json = self._get_schema_for_graph(query)
+
+        with self.database.snapshot() as snapshot:
+            params = None
+            param_types = None
+            if limit and limit > 0:
+                params = dict(limit=limit)
+
+            try:
+                results = snapshot.execute_sql(query, params=params, param_types=param_types)
+                rows = list(results)
+            except Exception as e:
+                return {}, [], [], self.schema_json, e
+
+            fields: List[SpannerFieldInfo] = get_as_field_info_list(results.fields)
+            data = {field.name: [] for field in fields}
+
+            if len(fields) == 0:
+                return SpannerQueryResult(
+                    data=data,
+                    fields=fields,
+                    rows=rows,
+                    schema_json=self.schema_json,
+                    error=None
+                )
+
+            for row_data in rows:
+                for field, value in zip(fields, row_data):
+                    if isinstance(value, JsonObject):
+                        data[field.name].append(json.loads(value.serialize()))
+                    else:
+                        data[field.name].append(value)
+
+            return SpannerQueryResult(
+                data=data,
+                fields=fields,
+                rows=rows,
+                schema_json=self.schema_json,
+                error=None
+            )

--- a/spanner_graphs/cloud_database.py
+++ b/spanner_graphs/cloud_database.py
@@ -23,14 +23,18 @@ from typing import Any, Dict, List, Tuple
 from google.cloud import spanner
 from google.cloud.spanner_v1 import JsonObject
 from google.api_core.client_options import ClientOptions
-from google.cloud.spanner_v1.types import StructType, Type
+from google.cloud.spanner_v1.types import StructType, Type, TypeCode
 import pydata_google_auth
 
-from spanner_graphs.database import SpannerDatabase, MockSpannerDatabase, SpannerQueryResult, SpannerFieldInfo, get_as_field_info_list
+from spanner_graphs.database import SpannerDatabase, MockSpannerDatabase, SpannerQueryResult, SpannerFieldInfo
 
 def _get_default_credentials_with_project():
     return pydata_google_auth.default(
         scopes=["https://www.googleapis.com/auth/cloud-platform"], use_local_webserver=False)
+
+def get_as_field_info_list(fields: List[StructType.Field]) -> List[SpannerFieldInfo]:
+  """Converts a list of StructType.Field to a list of SpannerFieldInfo."""
+  return [SpannerFieldInfo(name=field.name, typename=TypeCode(field.type_.code).name) for field in fields]
 
 class CloudSpannerDatabase(SpannerDatabase):
     """Concrete implementation for Spanner database on the cloud."""

--- a/spanner_graphs/conversion.py
+++ b/spanner_graphs/conversion.py
@@ -23,10 +23,11 @@ import json
 
 from google.cloud.spanner_v1.types import TypeCode, StructType
 
+from spanner_graphs.database import SpannerFieldInfo
 from spanner_graphs.graph_entities import Node, Edge
 from spanner_graphs.schema_manager import SchemaManager
 
-def get_nodes_edges(data: Dict[str, List[Any]], fields: List[StructType.Field], schema_json: dict = None) -> Tuple[List[Node], List[Edge]]:
+def get_nodes_edges(data: Dict[str, List[Any]], fields: List[SpannerFieldInfo], schema_json: dict = None) -> Tuple[List[Node], List[Edge]]:
     schema_manager = SchemaManager(schema_json)
     nodes: List[Node] = []
     edges: List[Edge] = []
@@ -37,15 +38,15 @@ def get_nodes_edges(data: Dict[str, List[Any]], fields: List[StructType.Field], 
     for field in fields:
         column_name = field.name
         column_data = data[column_name]
-        
+
         # Only process JSON and Array of JSON types
-        if field.type_.code not in [TypeCode.JSON, TypeCode.ARRAY]:
+        if field.typename not in ["JSON", "ARRAY"]:
             continue
 
         # Process each value in the column
         for value in column_data:
             items_to_process = []
-            
+
             # Handle both single JSON and arrays of JSON
             if isinstance(value, list):
                 items_to_process.extend(value)

--- a/spanner_graphs/conversion.py
+++ b/spanner_graphs/conversion.py
@@ -21,8 +21,6 @@ from __future__ import annotations
 from typing import Any, List, Dict, Tuple
 import json
 
-from google.cloud.spanner_v1.types import TypeCode, StructType
-
 from spanner_graphs.database import SpannerFieldInfo
 from spanner_graphs.graph_entities import Node, Edge
 from spanner_graphs.schema_manager import SchemaManager

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -25,11 +25,6 @@ import os
 import csv
 
 from dataclasses import dataclass
-from google.cloud import spanner
-from google.cloud.spanner_v1 import JsonObject
-from google.api_core.client_options import ClientOptions
-from google.cloud.spanner_v1.types import StructType, TypeCode, Type
-import pydata_google_auth
 
 class SpannerQueryResult(NamedTuple):
     # A dict where each key is a field name returned in the query and the list
@@ -70,28 +65,6 @@ class SpannerFieldInfo:
     name: str
     typename: str
 
-def get_as_field_info_list(fields: List[StructType.Field]) -> List[SpannerFieldInfo]:
-  """Converts a list of StructType.Field to a list of SpannerFieldInfo."""
-  return [SpannerFieldInfo(name=field.name, typename=field.type_.code.name) for field in fields]
-
-
-# Global dict of database instances created in a single session
-database_instances: dict[str, SpannerDatabase | MockSpannerDatabase] = {}
-
-def get_database_instance(project: str, instance: str, database: str, mock = False) -> SpannerDatabase:
-    if mock:
-        return MockSpannerDatabase()
-
-    key = f"{project}_{instance}_{database}"
-    db = database_instances.get(key)
-
-    # Currently, we only create and return CloudSpannerDatabase instances. In the future, different
-    # implementations could be introduced.
-    if not db:
-        db = CloudSpannerDatabase(project, instance, database)
-        database_instances[key] = db
-
-    return db
 
 class MockSpannerResult:
 

--- a/spanner_graphs/database.py
+++ b/spanner_graphs/database.py
@@ -37,7 +37,7 @@ class SpannerQueryResult(NamedTuple):
     # An optional field to return the schema as JSON
     schema_json: Any | None
     # The error message if any
-    error: Exception | None
+    err: Exception | None
 
 class SpannerDatabase(ABC):
     """The spanner class holding the database connection"""
@@ -129,7 +129,7 @@ class MockSpannerDatabase():
                     fields=fields,
                     rows=rows,
                     schema_json=self.schema_json,
-                    error=None
+                    err=None
                 )
 
         for i, row in enumerate(results):
@@ -143,5 +143,5 @@ class MockSpannerDatabase():
                 fields=fields,
                 rows=rows,
                 schema_json=self.schema_json,
-                error=None
+                err=None
             )

--- a/spanner_graphs/exec_env.py
+++ b/spanner_graphs/exec_env.py
@@ -1,0 +1,41 @@
+
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module maintains state for the execution environment of a session
+"""
+from typing import Dict, Union
+
+from spanner_graphs.database import SpannerDatabase, MockSpannerDatabase
+from spanner_graphs.cloud_database import CloudSpannerDatabase
+
+# Global dict of database instances created in a single session
+database_instances: Dict[str, Union[SpannerDatabase, MockSpannerDatabase]] = {}
+
+def get_database_instance(project: str, instance: str, database: str, mock = False):
+    if mock:
+        return MockSpannerDatabase()
+
+    key = f"{project}_{instance}_{database}"
+    db = database_instances.get(key)
+
+    # Currently, we only create and return CloudSpannerDatabase instances. In the future, different
+    # implementations could be introduced.
+    if not db:
+        db = CloudSpannerDatabase(project, instance, database)
+        database_instances[key] = db
+
+    return db
+

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -17,7 +17,7 @@ import socketserver
 import json
 import threading
 from enum import Enum
-from typing import Union
+from typing import Union, Dict, Any
 
 import requests
 import portpicker
@@ -206,49 +206,70 @@ def execute_node_expansion(
 
     return execute_query(project, instance, database, query, mock=False)
 
-def execute_query(project: str, instance: str, database: str, query: str, mock = False):
-    database = get_database_instance(project, instance, database, mock)
+def execute_query(
+    project: str,
+    instance: str,
+    database: str,
+    query: str,
+    mock: bool = False,
+) -> Dict[str, Any]:
+    """Executes a query against a database and formats the result.
 
+    Connects to a database, runs the query, and processes the resulting object.
+    On success, it formats the data into nodes and edges for graph visualization.
+    If the query fails, it returns a detailed error message, optionally
+    including the database schema to aid in debugging.
+
+    Args:
+        project: The cloud project ID.
+        instance: The database instance name.
+        database: The database name.
+        query: The query string to execute.
+        mock: If True, use a mock database instance for testing. Defaults to False.
+
+    Returns:
+        A dictionary containing either the structured 'response' with nodes,
+        edges, and other data, or an 'error' key with a descriptive message.
+    """
     try:
-        query_result, fields, rows, schema_json, err = database.execute_query(query)
-        if len(rows) == 0 and err : # if query returned an error
-            if schema_json: # if the schema exists
-                return {
-                    "response": {
-                        "schema": schema_json,
-                        "query_result": query_result,
-                        "nodes": [],
-                        "edges": [],
-                        "rows": []
-                    },
-                    "error": f"We've detected an error in your query. To help you troubleshoot, the graph schema's layout is shown above." + "\n\n" + f"Query error: \n{getattr(err, 'message', str(err))}"
-                }
-            if not schema_json: # if the schema does not exist
-                return {
-                    "response": {
-                        "schema": schema_json,
-                        "query_result": query_result,
-                        "nodes": [],
-                        "edges": [],
-                        "rows": []
-                    },
-                    "error": f"Query error: \n{getattr(err, 'message', str(err))}"
-                }
-        nodes, edges = get_nodes_edges(query_result, fields, schema_json)
+        db_instance = get_database_instance(project, instance, database, mock)
+        result: SpannerQueryResult = db_instance.execute_query(query)
+
+        if len(result.rows) == 0 and result.err:
+            error_message = f"Query error: \n{getattr(result.err, 'message', str(result.err))}"
+            if result.schema_json:
+                # Prepend a helpful message if the schema is available
+                error_message = (
+                    "We've detected an error in your query. To help you troubleshoot, "
+                    "the graph schema's layout is shown above.\n\n" + error_message
+                )
+
+            # Consolidate the repetitive error response into a single return
+            return {
+                "response": {
+                    "schema": result.schema_json,
+                    "query_result": result.data,
+                    "nodes": [],
+                    "edges": [],
+                    "rows": [],
+                },
+                "error": error_message,
+            }
+
+        # Process a successful query result
+        nodes, edges = get_nodes_edges(result.data, result.fields, result.schema_json)
 
         return {
             "response": {
                 "nodes": [node.to_json() for node in nodes],
                 "edges": [edge.to_json() for edge in edges],
-                "schema": schema_json,
-                "rows": rows,
-                "query_result": query_result
+                "schema": result.schema_json,
+                "rows": result.rows,
+                "query_result": result.data,
             }
         }
     except Exception as e:
-        return {
-            "error": getattr(e, "message", str(e))
-        }
+        return {"error": getattr(e, "message", str(e))}
 
 
 class GraphServer:

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -25,7 +25,7 @@ import atexit
 from google.cloud.spanner_v1 import TypeCode
 
 from spanner_graphs.conversion import get_nodes_edges
-from spanner_graphs.database import get_database_instance
+from spanner_graphs.exec_env import get_database_instance
 
 
 # Mapping of string types from frontend to Spanner TypeCode enum values

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -25,7 +25,7 @@ import atexit
 
 from spanner_graphs.conversion import get_nodes_edges
 from spanner_graphs.exec_env import get_database_instance
-
+from spanner_graphs.database import SpannerQueryResult
 
 # Supported types for a property
 PROPERTY_TYPE_SET = {

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -33,7 +33,7 @@ import ipywidgets as widgets
 from ipywidgets import interact
 from jinja2 import Template
 
-from spanner_graphs.database import get_database_instance
+from spanner_graphs.exec_env import get_database_instance
 from spanner_graphs.graph_server import (
     GraphServer, execute_query, execute_node_expansion,
     validate_node_expansion_request

--- a/tests/cloud_database_test.py
+++ b/tests/cloud_database_test.py
@@ -22,13 +22,13 @@ from unittest.mock import patch, MagicMock
 
 from google.cloud.spanner_v1.types import Type, TypeCode, StructType
 
-from spanner_graphs.database import SpannerDatabase
-
+from spanner_graphs.cloud_database import CloudSpannerDatabase
+from spanner_graphs.database import SpannerFieldInfo
 
 class TestDatabase(unittest.TestCase):
-    """Test cases for the SpannerDatabase class"""
+    """Test cases for the CloudSpannerDatabase class"""
 
-    @patch("spanner_graphs.database.spanner.Client")
+    @patch("spanner_graphs.cloud_database.spanner.Client")
     def test_execute_query(self, mock_client: MagicMock) -> None:
         """Test that a query is executed correctly"""
         mock_instance = MagicMock()
@@ -51,11 +51,11 @@ class TestDatabase(unittest.TestCase):
             StructType.Field(name="field3", type_=Type(code=TypeCode.JSON)),
         ]
 
-        db = SpannerDatabase("test_project", "test_instance", "test_database")
+        db = CloudSpannerDatabase("test_project", "test_instance", "test_database")
         result = db.execute_query("SELECT * FROM test", is_test_query=True)
 
-        self.assertEqual(result[0]["field1"], ['{"key": "value1"}'])
-        self.assertEqual(result[1][0].name, "field1")
+        self.assertEqual(result.data["field1"], ['{"key": "value1"}'])
+        self.assertEqual(result.fields[0].name, "field1")
 
 
 if __name__ == "__main__":

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -23,7 +23,7 @@ import json
 from google.cloud.spanner_v1.types import StructType, Type, TypeCode
 
 from spanner_graphs.conversion import get_nodes_edges
-from spanner_graphs.database import MockSpannerDatabase
+from spanner_graphs.database import SpannerFieldInfo, MockSpannerDatabase
 
 
 class TestConversion(unittest.TestCase):
@@ -103,9 +103,9 @@ class TestConversion(unittest.TestCase):
         }
 
         # Create a mock field for the column
-        field = StructType.Field(
+        field = SpannerFieldInfo(
             name="column1",
-            type_=Type(code=TypeCode.JSON)
+            typename="JSON"
         )
 
         # Convert data to nodes and edges
@@ -165,9 +165,9 @@ class TestConversion(unittest.TestCase):
         }
 
         # Create a mock field for the column
-        field = StructType.Field(
+        field = SpannerFieldInfo(
             name="column1",
-            type_=Type(code=TypeCode.JSON)
+            typename="JSON"
         )
 
         # Convert data to nodes and edges
@@ -211,9 +211,9 @@ class TestConversion(unittest.TestCase):
         }
 
         # Create a mock field for the column
-        field = StructType.Field(
+        field = SpannerFieldInfo(
             name="column1",
-            type_=Type(code=TypeCode.JSON)
+            typename="JSON"
         )
 
         # Convert data to nodes and edges

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -38,10 +38,10 @@ class TestConversion(unittest.TestCase):
         """
         # Get data from mock database
         mock_db = MockSpannerDatabase()
-        data, fields, _, schema_json, _ = mock_db.execute_query("")
+        query_result = mock_db.execute_query("")
 
         # Convert data to nodes and edges
-        nodes, edges = get_nodes_edges(data, fields)
+        nodes, edges = get_nodes_edges(query_result.data, query_result.fields)
 
         # Verify we got some nodes and edges
         self.assertTrue(len(nodes) > 0, "Should have at least one node")

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import unittest
 import json
 
-from google.cloud.spanner_v1.types import StructType, Type, TypeCode
-
 from spanner_graphs.conversion import get_nodes_edges
 from spanner_graphs.database import SpannerFieldInfo, MockSpannerDatabase
 

--- a/tests/graph_server_test.py
+++ b/tests/graph_server_test.py
@@ -1,10 +1,9 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from google.cloud.spanner_v1 import TypeCode
 import json
 
 from spanner_graphs.graph_server import (
-    validate_property_type,
+    is_valid_property_type,
     execute_node_expansion,
 )
 
@@ -12,26 +11,25 @@ class TestPropertyTypeHandling(unittest.TestCase):
     def test_validate_property_type_valid_types(self):
         """Test that valid property types are correctly validated and converted."""
         test_cases = [
-            ('INT64', TypeCode.INT64),
-            ('STRING', TypeCode.STRING),
-            ('BOOL', TypeCode.BOOL),
-            ('NUMERIC', TypeCode.NUMERIC),
-            ('FLOAT32', TypeCode.FLOAT32),
-            ('FLOAT64', TypeCode.FLOAT64),
-            ('DATE', TypeCode.DATE),
-            ('TIMESTAMP', TypeCode.TIMESTAMP),
-            ('BYTES', TypeCode.BYTES),
-            ('ENUM', TypeCode.ENUM),
+            'INT64',
+            'STRING',
+            'BOOL',
+            'NUMERIC',
+            'FLOAT32',
+            'FLOAT64',
+            'DATE',
+            'TIMESTAMP',
+            'BYTES',
+            'ENUM',
             # Test case insensitivity
-            ('int64', TypeCode.INT64),
-            ('string', TypeCode.STRING),
-            ('Bool', TypeCode.BOOL),
+            'int64',
+            'string',
+            'Bool',
         ]
 
-        for input_type, expected_type in test_cases:
+        for input_type in test_cases:
             with self.subTest(input_type=input_type):
-                result = validate_property_type(input_type)
-                self.assertEqual(result, expected_type)
+                self.assertTrue(is_valid_property_type(input_type))
 
     def test_validate_property_type_invalid_types(self):
         """Test that invalid property types raise appropriate errors."""
@@ -48,7 +46,7 @@ class TestPropertyTypeHandling(unittest.TestCase):
         for invalid_type in invalid_types:
             with self.subTest(invalid_type=invalid_type):
                 with self.assertRaises(ValueError) as cm:
-                    validate_property_type(invalid_type)
+                    is_valid_property_type(invalid_type)
 
                 if not invalid_type:
                     self.assertEqual(str(cm.exception), "Property type must be provided")

--- a/tests/node_expansion_test.py
+++ b/tests/node_expansion_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 import json
 
 from spanner_graphs.magics import receive_node_expansion_request
-from spanner_graphs.graph_server import EdgeDirection, TypeCode
+from spanner_graphs.graph_server import EdgeDirection
 
 class TestNodeExpansion(unittest.TestCase):
     def setUp(self):
@@ -35,7 +35,7 @@ class TestNodeExpansion(unittest.TestCase):
                 "edges": []
             }
         }
-        
+
         # Create request and params objects
         request = {
             "uid": "node-123",
@@ -46,7 +46,7 @@ class TestNodeExpansion(unittest.TestCase):
             "direction": "OUTGOING",
             "edge_label": "CONNECTS_TO"
         }
-        
+
         params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
@@ -54,13 +54,13 @@ class TestNodeExpansion(unittest.TestCase):
             "graph": "test_graph",
             "mock": False
         })
-        
+
         # Call the function
         result = receive_node_expansion_request(request, params)
-        
+
         # Verify execute_node_expansion was called with correct parameters
         mock_execute.assert_called_once_with(params, request)
-        
+
         # Verify the result is wrapped in JSON
         self.assertEqual(result.data, mock_execute.return_value)
 
@@ -76,7 +76,7 @@ class TestNodeExpansion(unittest.TestCase):
                 "edges": []
             }
         }
-        
+
         # Create request without edge_label and params objects
         request = {
             "uid": "node-123",
@@ -87,7 +87,7 @@ class TestNodeExpansion(unittest.TestCase):
             "direction": "OUTGOING"
             # No edge_label
         }
-        
+
         params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
@@ -95,22 +95,22 @@ class TestNodeExpansion(unittest.TestCase):
             "graph": "test_graph",
             "mock": False
         })
-        
+
         # Call the function
         result = receive_node_expansion_request(request, params)
-        
+
         # Verify execute_node_expansion was called with correct parameters
         mock_execute.assert_called_once_with(params, request)
-        
+
         # Verify the result is wrapped in JSON
         self.assertEqual(result.data, mock_execute.return_value)
-        
+
     @patch('spanner_graphs.magics.validate_node_expansion_request')
     def test_invalid_property_type(self, mock_validate):
         """Test that invalid property types are correctly caught."""
         # Set up the mock to raise a ValueError when called with invalid data
         mock_validate.side_effect = ValueError("Invalid property type")
-        
+
         # Create a request with invalid property type
         request = {
             "uid": "node-123",
@@ -120,7 +120,7 @@ class TestNodeExpansion(unittest.TestCase):
             ],
             "direction": "OUTGOING"
         }
-        
+
         params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
@@ -132,13 +132,13 @@ class TestNodeExpansion(unittest.TestCase):
         # Call the function and verify it returns an error response
         result = receive_node_expansion_request(request, params)
         self.assertIn("error", result.data)
-        
+
     @patch('spanner_graphs.magics.validate_node_expansion_request')
     def test_invalid_direction(self, mock_validate):
         """Test that invalid directions are correctly caught."""
         # Set up the mock to raise a ValueError when called with invalid data
         mock_validate.side_effect = ValueError("Invalid direction")
-        
+
         # Create a request with invalid direction
         request = {
             "uid": "node-123",
@@ -148,7 +148,7 @@ class TestNodeExpansion(unittest.TestCase):
             ],
             "direction": "INVALID_DIRECTION"
         }
-        
+
         params = json.dumps({
             "project": "test-project",
             "instance": "test-instance",
@@ -162,4 +162,4 @@ class TestNodeExpansion(unittest.TestCase):
         self.assertIn("error", result.data)
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
    The google.cloud.spanner.TypeCode was used to validate supported
    types for properties. However, the type information is always
    received as a string from the JS client. It is only internally converted
    to a TypeCode for verification.
    
    Comparing against the TypeCode does not make the validation any more
    robust than just confirming if the strings themselves are valid type
    strings.
    
    Removing reliance on TypeCode also makes GraphServer database agnostic.