### PR TITLE
Add the concept of DB selectors

### DIFF
--- a/frontend/static/dev.html
+++ b/frontend/static/dev.html
@@ -484,11 +484,20 @@ LIMIT 50"></textarea>
                 window.app.tearDown();
             }
 
+            let selector;
+            if (mock) {
+                selector = { env: 'SpannerEnv.MOCK' };
+            } else {
+                selector = {
+                    env: 'SpannerEnv.CLOUD',
+                    project: project,
+                    instance: instance,
+                    database: database
+                };
+            }
+
             const params = {
-                'project': project,
-                'instance': instance,
-                'database': database,
-                'mock': mock,
+                'selector': selector,
                 'graph': graph
             };
 

--- a/frontend/static/test.html
+++ b/frontend/static/test.html
@@ -68,12 +68,12 @@ limitations under the License.
         }
 
         const mount = document.querySelector('.mount-spanner-test');
-        params = {
-            'project': 'project-foo',
-            'instance': 'instance-foo',
-            'database': 'database-foo',
-            'mock': true
-        }
+        const params = {
+            selector: {
+                env: 'SpannerEnv.MOCK'
+            },
+            graph: ''
+        };
         window.app = new SpannerApp({
             id: 'spanner-test', port:'', params:params, mount:mount, query: ''
         });

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -25,7 +25,7 @@ import atexit
 
 from spanner_graphs.conversion import get_nodes_edges
 from spanner_graphs.exec_env import get_database_instance
-from spanner_graphs.database import SpannerQueryResult
+from spanner_graphs.database import DatabaseSelector, SpannerQueryResult, SpannerEnv
 
 # Supported types for a property
 PROPERTY_TYPE_SET = {
@@ -51,6 +51,24 @@ class NodePropertyForDataExploration:
 class EdgeDirection(Enum):
     INCOMING = "INCOMING"
     OUTGOING = "OUTGOING"
+
+
+def dict_to_selector(selector_dict: Dict[str, Any]) -> DatabaseSelector:
+    """
+    Picks the correct DB selector based on the environment the server is running in.
+    """
+    try:
+        env = SpannerEnv[selector_dict['env'].split('.')[-1]]
+        if env == SpannerEnv.CLOUD:
+            return DatabaseSelector.cloud(selector_dict['project'], selector_dict['instance'], selector_dict['database'])
+        elif env == SpannerEnv.INFRA:
+            return DatabaseSelector.infra(selector_dict['infra_db_path'])
+        elif env == SpannerEnv.MOCK:
+            return DatabaseSelector.mock()
+        raise ValueError(f"Invalid env in selector dict: {selector_dict}")
+    except Exception as e:
+        print (f"Unexpected error when fetching selector: {e}")
+
 
 def is_valid_property_type(property_type: str) -> bool:
     """
@@ -79,7 +97,7 @@ def is_valid_property_type(property_type: str) -> bool:
     return True
 
 def validate_node_expansion_request(data) -> (list[NodePropertyForDataExploration], EdgeDirection):
-    required_fields = ["project", "instance", "database", "graph", "uid", "node_labels", "direction"]
+    required_fields = ["uid", "node_labels", "direction"]
     missing_fields = [field for field in required_fields if data.get(field) is None]
 
     if missing_fields:
@@ -146,7 +164,8 @@ def validate_node_expansion_request(data) -> (list[NodePropertyForDataExploratio
     return validated_properties, direction
 
 def execute_node_expansion(
-    params_str: str,
+    selector_dict: Dict[str, Any],
+    graph: str,
     request: dict) -> dict:
     """Execute a node expansion query to find connected nodes and edges.
 
@@ -158,13 +177,9 @@ def execute_node_expansion(
         dict: A dictionary containing the query response with nodes and edges.
     """
 
-    params = json.loads(params_str)
-    node_properties, direction = validate_node_expansion_request(params | request)
+    node_properties, direction = validate_node_expansion_request(request)
 
-    project = params.get("project")
-    instance = params.get("instance")
-    database = params.get("database")
-    graph = params.get("graph")
+    selector = dict_to_selector(selector_dict)
     uid = request.get("uid")
     node_labels = request.get("node_labels")
     edge_label = request.get("edge_label")
@@ -204,14 +219,11 @@ def execute_node_expansion(
         RETURN TO_JSON(e) as e, TO_JSON(d) as d
         """
 
-    return execute_query(project, instance, database, query, mock=False)
+    return execute_query(selector_dict, query)
 
 def execute_query(
-    project: str,
-    instance: str,
-    database: str,
+    selector_dict: Dict[str, Any],
     query: str,
-    mock: bool = False,
 ) -> Dict[str, Any]:
     """Executes a query against a database and formats the result.
 
@@ -220,19 +232,14 @@ def execute_query(
     If the query fails, it returns a detailed error message, optionally
     including the database schema to aid in debugging.
 
-    Args:
-        project: The cloud project ID.
-        instance: The database instance name.
-        database: The database name.
-        query: The query string to execute.
-        mock: If True, use a mock database instance for testing. Defaults to False.
-
     Returns:
         A dictionary containing either the structured 'response' with nodes,
         edges, and other data, or an 'error' key with a descriptive message.
     """
     try:
-        db_instance = get_database_instance(project, instance, database, mock)
+        selector = dict_to_selector(selector_dict)
+        db_instance = get_database_instance(selector)
+
         result: SpannerQueryResult = db_instance.execute_query(query)
 
         if len(result.rows) == 0 and result.err:
@@ -382,32 +389,25 @@ class GraphServerHandler(http.server.SimpleHTTPRequestHandler):
         data = self.parse_post_data()
         params = json.loads(data["params"])
         response = execute_query(
-            project=params["project"],
-            instance=params["instance"],
-            database=params["database"],
-            query=data["query"],
-            mock=params["mock"]
+            selector_dict=params["selector"],
+            query=data["query"]
         )
         self.do_data_response(response)
 
     def handle_post_node_expansion(self):
-        """Handle POST requests for node expansion.
-
-        Expects a JSON payload with:
-        - params: A JSON string containing connection parameters (project, instance, database, graph)
-        - request: A dictionary with node details (uid, node_labels, node_properties, direction, edge_label)
-        """
         try:
             data = self.parse_post_data()
+            params = json.loads(data.get("params"))
+            selector_dict = params["selector"]
+            graph = params.get("graph")
+            request_data = data.get("request")
 
-            # Execute node expansion with:
-            # - params_str: JSON string with connection parameters (project, instance, database, graph)
-            # - request: Dict with node details (uid, node_labels, node_properties, direction, edge_label)
             self.do_data_response(execute_node_expansion(
-                params_str=data.get("params"),
-                request=data.get("request")
+                selector_dict=selector_dict,
+                graph=graph,
+                request=request_data
             ))
-        except BaseException as e:
+        except Exception as e:
             self.do_error_response(e)
             return
 

--- a/spanner_graphs/graph_server.py
+++ b/spanner_graphs/graph_server.py
@@ -179,7 +179,6 @@ def execute_node_expansion(
 
     node_properties, direction = validate_node_expansion_request(request)
 
-    selector = dict_to_selector(selector_dict)
     uid = request.get("uid")
     node_labels = request.get("node_labels")
     edge_label = request.get("edge_label")

--- a/spanner_graphs/graph_visualization.py
+++ b/spanner_graphs/graph_visualization.py
@@ -57,7 +57,7 @@ def generate_visualization_html(query: str, port: int, params: str):
             search_dir = parent
 
         template_content = _load_file([search_dir, 'frontend', 'static', 'jupyter.html'])
-        
+
         # Load the JavaScript bundle directly
         js_file_path = os.path.join(search_dir, 'third_party', 'index.js')
         try:

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -224,7 +224,6 @@ class NetworkVisualizationMagics(Magics):
             self.visualize()
         except BaseException as e:
             print(f"Error: {e}")
-            print("Usage: %%spanner_graph --infra_db_path <db_path>")
             print("       %%spanner_graph --project <proj> --instance <inst> --database <db>")
             print("       %%spanner_graph --mock")
             print("       Graph query here...")

--- a/spanner_graphs/magics.py
+++ b/spanner_graphs/magics.py
@@ -24,6 +24,7 @@ import os
 import sys
 from threading import Thread
 import re
+from dataclasses import is_dataclass, asdict
 
 from IPython.core.display import HTML, JSON
 from IPython.core.magic import Magics, magics_class, cell_magic
@@ -33,6 +34,7 @@ import ipywidgets as widgets
 from ipywidgets import interact
 from jinja2 import Template
 
+from spanner_graphs.database import DatabaseSelector
 from spanner_graphs.exec_env import get_database_instance
 from spanner_graphs.graph_server import (
     GraphServer, execute_query, execute_node_expansion,
@@ -86,11 +88,13 @@ def is_colab() -> bool:
 
 def receive_query_request(query: str, params: str):
     params_dict = json.loads(params)
-    return JSON(execute_query(project=params_dict["project"],
-                              instance=params_dict["instance"],
-                              database=params_dict["database"],
-                              query=query,
-                              mock=params_dict["mock"]))
+    selector_dict = params_dict.get("selector")
+    if not selector_dict:
+        return JSON({"error": "Missing selector in params"})
+    try:
+        return JSON(execute_query(selector_dict=selector_dict, query=query))
+    except Exception as e:
+        return JSON({"error": str(e)})
 
 def receive_node_expansion_request(request: dict, params_str: str):
     """Handle node expansion requests in Google Colab environment
@@ -103,11 +107,8 @@ def receive_node_expansion_request(request: dict, params_str: str):
             - direction: str - Direction of expansion ("INCOMING" or "OUTGOING")
             - edge_label: Optional[str] - Label of edges to filter by
         params_str: A JSON string containing connection parameters:
-            - project: str - GCP project ID
-            - instance: str - Spanner instance ID
-            - database: str - Spanner database ID
+            - selector: Dict - The DatabaseSelector object as a dict
             - graph: str - Graph name
-            - mock: bool - Whether to use mock data
 
     Returns:
         JSON: A JSON-serialized response containing either:
@@ -115,9 +116,23 @@ def receive_node_expansion_request(request: dict, params_str: str):
             - An error message if the request failed
     """
     try:
-        return JSON(execute_node_expansion(params_str, request))
+        params_dict = json.loads(params_str)
+        selector_dict = params_dict.get("selector")
+        graph = params_dict.get("graph")
+        if not selector_dict:
+            return JSON({"error": "Missing selector in params"})
+
+        return JSON(execute_node_expansion(selector_dict=selector_dict, graph=graph, request=request))
     except BaseException as e:
-        return JSON({"error": e})
+        return JSON({"error": str(e)})
+
+def custom_json_serializer(o):
+    """A JSON serializer that handles dataclasses and enums."""
+    if is_dataclass(o):
+        return asdict(o)
+    if isinstance(o, Enum):
+        return f"{o.__class__.__name__}.{o.name}"
+    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
 
 @magics_class
 class NetworkVisualizationMagics(Magics):
@@ -129,6 +144,7 @@ class NetworkVisualizationMagics(Magics):
         self.limit = 5
         self.args = None
         self.cell = None
+        self.selector = None
 
         if is_colab():
             from google.colab import output
@@ -149,17 +165,18 @@ class NetworkVisualizationMagics(Magics):
             if match:
                 graph = match.group(1)
 
+        # Pack the selector and graph into the params to be sent to the GraphServer
+        params = {
+            "selector": self.selector,
+            "graph": graph
+        }
+
         # Generate the HTML content
         html_content = generate_visualization_html(
             query=self.cell,
             port=GraphServer.port,
-            params=json.dumps({
-                "project": self.args.project,
-                "instance": self.args.instance,
-                "database": self.args.database,
-                "mock": self.args.mock,
-                "graph": graph
-            }))
+            params=json.dumps(params, default=custom_json_serializer))
+
         display(HTML(html_content))
 
     @cell_magic
@@ -177,34 +194,40 @@ class NetworkVisualizationMagics(Magics):
         parser.add_argument("--mock",
                             action="store_true",
                             help="Use mock database")
+        parser.add_argument("--infra_db_path",
+                            action="store_true",
+                            help="Connect to internal Infra Spanner")
 
         try:
             args = parser.parse_args(line.split())
-            if not args.mock:
-                if not (args.project and args.instance and args.database):
+            selector = None
+            if args.mock:
+                selector = DatabaseSelector.mock()
+            elif args.infra_db_path:
+                selector = DatabaseSelector.infra(infra_db_path=args.database)
+            else:
+                if not (args.project and args.instance):
                     raise ValueError(
-                        "Please provide `--project`, `--instance`, "
-                        "and `--database` values for your query.")
-                if not cell or not cell.strip():
-                    print("Error: Query is required.")
-                    return
+                        "Please provide `--project` and `--instance` for Cloud Spanner."
+                    )
+                selector = DatabaseSelector.cloud(args.project, args.instance, args.database)
 
-            self.args = parser.parse_args(line.split())
+            if not args.mock and (not cell or not cell.strip()):
+                print("Error: Query is required.")
+                return
+
+            self.args = args
             self.cell = cell
-            self.database = get_database_instance(
-                self.args.project,
-                self.args.instance,
-                self.args.database,
-                mock=self.args.mock)
+            self.selector = selector
+            self.database = get_database_instance(self.selector)
             clear_output(wait=True)
             self.visualize()
         except BaseException as e:
             print(f"Error: {e}")
-            print("Usage: %%spanner_graph --project PROJECT_ID "
-                  "--instance INSTANCE_ID --database DATABASE_ID "
-                  "[--mock] ")
+            print("Usage: %%spanner_graph --infra_db_path <db_path>")
+            print("       %%spanner_graph --project <proj> --instance <inst> --database <db>")
+            print("       %%spanner_graph --mock")
             print("       Graph query here...")
-
 
 def load_ipython_extension(ipython):
     """Registration function"""


### PR DESCRIPTION
This change is added to minimize code-duplication between internal and OSS codebases.

The primary difference between internal and cloud is the params used to connect to them. We can create the concept of DB selectors which encapsulate details of the underlying DB being connected to. Hence, instead of passing cloud specific parameters (`--database/--instance/--project`), these selectors can be plumbed through the code.

- 3 types of selectors are implemented: CLOUD, INFRA, MOCK
- Passing the following options to %%spanner_graphs selects the appropriate DB:
  - `--mock` selects a Mock Spanner database.
  - `--project <> --instance <> --database` selects a Cloud Spanner database.
  - `--infra_db_path <>` selects an Infra database
- Core cloud and infra related database code already separated. cloud_database.py will be available in OSS and the infra version will not. So `infra_db_path` will not work in OSS and vice versa. MOCK will be supported in both internal and OSS.

- A new JSON based wire format between JS and Python is added: {
 "selector":
  {"env": "SpannerEnv.MOCK/CLOUD/INFRA", "project": "<>", "instance": "<>", "database": "<>", "infra_db_path": "<>"}, "graph": "<>" }

For example the protocol for cloud could look like: {
 "selector":
 {"env": "SpannerEnv.CLOUD",
  "project": "span-cloud-testing",
  "instance": "graph-demo",
  "database": "viz-demo",
  "infra_db_path": null},
 "graph": "FinGraph"
}

Similarly INFRA would have infra_db_path populated and the rest as null.